### PR TITLE
Add proof of the formula of inclusion-exclusion in proba.v

### DIFF
--- a/Reals_ext.v
+++ b/Reals_ext.v
@@ -342,3 +342,6 @@ move=> [H1 H2] [H H3]; case: (Rtotal_order a b) => [H0|[H0|H0]].
 - rewrite geR0_norm; last by fourier.
   apply: (@leR_trans a); [fourier|exact/(leR_trans H2)/leR_maxl].
 Qed.
+
+Lemma Rplus_minus_assoc (r1 r2 r3 : R) : (r1 + r2 - r3 = r1 + (r2 - r3))%R.
+Proof. by rewrite /Rminus Rplus_assoc. Qed.

--- a/proba.v
+++ b/proba.v
@@ -40,24 +40,26 @@ Require Import ssrR Reals_ext logb ssr_ext ssralg_ext bigop_ext Rbigop.
       Expected value of a random variable
   18. Section expected_value_for_standard_random_variables.
       Properties of the expected value of standard random variables:
-  19. Section markov_inequality.
-  20. Section variance_definition.
-  21. Section variance_properties.
-  22. Section chebyshev.
+  19. Section probability_inclusion_exclusion.
+      An algebraic proof of the formula of inclusion-exclusion.
+  20. Section markov_inequality.
+  21. Section variance_definition.
+  22. Section variance_properties.
+  23. Section chebyshev.
       Chebyshev's Inequality
-  23. Section joint_dist.
+  24. Section joint_dist.
       Joint Distribution
-  24. Section identically_distributed.
+  25. Section identically_distributed.
       Identically Distributed Random Variables
-  25. Section independent_random_variables.
-  26. Section sum_two_rand_var_def.
+  26. Section independent_random_variables.
+  27. Section sum_two_rand_var_def.
       The sum of two random variables
-  27. Section sum_two_rand_var.
-  28. Section sum_n_rand_var_def.
-  29. Section sum_n_rand_var.
-  30. Section sum_n_independent_rand_var_def.
-  31. Section sum_n_independent_rand_var.
-  32. Section weak_law_of_large_numbers.
+  28. Section sum_two_rand_var.
+  29. Section sum_n_rand_var_def.
+  30. Section sum_n_rand_var.
+  31. Section sum_n_independent_rand_var_def.
+  32. Section sum_n_independent_rand_var.
+  33. Section weak_law_of_large_numbers.
 *)
 
 Set Implicit Arguments.
@@ -967,6 +969,336 @@ rewrite 2!ExE /tuple1_of_rvar /=; apply big_rV_1 => // m.
 by rewrite -TupleDist1E.
 Qed.
 
+(** ** An algebraic proof of the formula of inclusion-exclusion *)
+
+Section probability_inclusion_exclusion.
+(** This section gathers a proof of the formula of inclusion-exclusion
+    contributed by Erik Martin-Dorel: the corresponding theorem is named
+    [Pr_bigcup_incl_excl] and is more general than lemma [Pr_bigcup]. *)
+Variable A : finType.
+Variable P : dist A.
+
+Lemma bigmul_eq0 (C : finType) (p : pred C) (F : C -> R) :
+  (exists2 i : C, p i & F i = R0) <-> \big[Rmult/R1]_(i : C | p i) F i = R0.
+Proof.
+split.
+{ by case => [i Hi Hi0]; rewrite (bigD1 i) //= Hi0 Rmult_0_l. }
+apply big_ind.
+- by move=> K; exfalso; auto with real.
+- move=> x y Hx Hy Hxy.
+  have [Hx0|Hy0] := Rmult_integral _ _ Hxy; [exact: Hx|exact: Hy].
+- move=> i Hi Hi0; by exists i.
+Qed.
+
+Lemma setDUKl (T : finType) (a b : {set T}) : (a :|: b) :\: a = b :\: a.
+Proof. by rewrite setDUl setDv set0U. Qed.
+
+Lemma Pr_union_eq (E1 E2 : {set A}) :
+  Pr P (E1 :|: E2) = (Pr P E1 + Pr P E2 - Pr P (E1 :&: E2))%R.
+Proof.
+rewrite -[E1 :|: E2](setID _ E1) Pr_union_disj; last first.
+{ rewrite setDE -setIA [E1 :&: _]setIC -setIA [~: E1 :&: _]setIC setICr.
+  by rewrite !setI0. }
+rewrite setUK setDUKl -{1}[E2 in RHS](setID _ E1) Pr_union_disj; last first.
+{ rewrite setDE -setIA [E1 :&: _]setIC -setIA [~: E1 :&: _]setIC setICr.
+  by rewrite !setI0. }
+by rewrite setIC; ring.
+Qed.
+
+(** *** A theory of indicator functions from [A : finType] to [R] *)
+
+Definition Ind (s : {set A}) (x : A) : R := if x \in s then R1 else R0.
+
+Lemma Ind_set0 (x : A) : Ind set0 x = R0.
+Proof. by rewrite /Ind inE. Qed.
+
+Lemma Ind_inP (s : {set A}) (x : A) : reflect (Ind s x = R1) (x \in s).
+Proof.
+apply: (iffP idP); rewrite /Ind; first by move->.
+by case: ifP =>//; auto with real.
+Qed.
+
+Lemma Ind_notinP (s : {set A}) (x : A) : reflect (Ind s x = R0) (x \notin s).
+Proof.
+apply: (iffP idP); rewrite /Ind => Hmain.
+  by rewrite ifF //; exact: negbTE.
+by apply: negbT; case: ifP Hmain =>// _ H10; exfalso; auto with real.
+Qed.
+
+Lemma Ind_cap (S1 S2 : {set A}) (x : A) :
+  Ind (S1 :&: S2) x = (Ind S1 x * Ind S2 x)%R.
+Proof. by rewrite /Ind inE; case: in_mem; case: in_mem=>/=; auto with real. Qed.
+
+Lemma Ind_bigcap I (e : I -> {set A}) (r : seq I) (p : pred I) x :
+  Ind (\bigcap_(j <- r | p j) e j) x = \big[Rmult/R1]_(j <- r | p j) (Ind (e j) x).
+Proof.
+apply (big_ind2 (R1 := {set A}) (R2 := R)); last done.
+- by rewrite /Ind inE.
+- by move=> sa a sb b Ha Hb; rewrite -Ha -Hb; apply: Ind_cap.
+Qed.
+
+(** *** Extra support results for the expected value *)
+
+(** Remark:
+
+    Random variables [X : rvar A] are defined as a record
+    gathering a distribution [P : dist A] and a function [f : A -> R].
+
+    For convenience, we locally define the function [rv] for building
+    such random variables, endowed with the ambient distribution [P]. *)
+
+Let rv : (A -> R) -> rvar A := mkRvar P.
+
+Lemma E_Ind s : `E (rv (Ind s)) = Pr P s.
+Proof.
+rewrite ExE /Ex /Ind /Pr (bigID (mem s)) /=.
+rewrite [X in _ + X = _]big1; last by move=> i /negbTE ->; rewrite Rmult_0_l.
+by rewrite Rplus_0_r; apply: eq_bigr => i ->; rewrite Rmult_1_l.
+Qed.
+
+Lemma E_ext X2 X1 : X1 =1 X2 -> `E (rv X1) = `E (rv X2).
+Proof. by move=> Heq; rewrite !ExE; apply: eq_bigr => i Hi /=; rewrite Heq. Qed.
+
+Lemma E_add X1 X2 : `E (rv (fun w => X1 w + X2 w)) = `E (rv X1) + `E (rv X2).
+Proof.
+rewrite !ExE; erewrite eq_bigr. (* to replace later with under *)
+  2: by move=> i Hi; rewrite Rmult_plus_distr_r.
+by rewrite big_split.
+Qed.
+
+Lemma E_rsum I r p (X : I -> A -> R) :
+  `E (rv (fun x => \big[Rplus/R0]_(i <- r | p i) X i x)) =
+  \big[Rplus/R0]_(i <- r | p i) (`E (rv (X i))).
+Proof.
+rewrite ExE /=; erewrite eq_bigr. (* to replace later with under *)
+  2: by move=> a Ha; rewrite big_distrl.
+by rewrite exchange_big /=; apply: eq_bigr => i Hi; rewrite ExE.
+Qed.
+
+Lemma E_scaler X1 r2 : `E (rv (fun w => X1 w * r2)) = `E (rv X1) * r2.
+Proof.
+rewrite !ExE big_distrl /=; apply: eq_bigr => i Hi.
+by rewrite !Rmult_assoc; congr Rmult; rewrite Rmult_comm.
+Qed.
+
+Lemma E_scalel r1 X2 : `E (rv (fun w => r1 * X2 w)) = r1 * `E (rv X2).
+Proof.
+rewrite !ExE big_distrr /=; apply: eq_bigr => i Hi.
+by rewrite !Rmult_assoc; congr Rmult; rewrite Rmult_comm.
+Qed.
+
+(** [bigA_distr] is a specialization of [bigA_distr_bigA] and at the same
+    time a generalized version of [GRing.exprDn] for iterated prod. *)
+Lemma bigA_distr (R : Type) (zero one : R) (times : Monoid.mul_law zero)
+    (plus : Monoid.add_law zero times)
+    (I : finType)
+    (F1 F2 : I -> R) :
+  \big[times/one]_(i in I) plus (F1 i) (F2 i) =
+  \big[plus/zero]_(0 <= k < #|I|.+1)
+  \big[plus/zero]_(J in {set I} | #|J| == k)
+  \big[times/one]_(j in I) (if j \notin J then F1 j else F2 j).
+Proof.
+pose F12 i (j : bool) := if ~~ j then F1 i else F2 i.
+erewrite eq_bigr. (* to replace later with under *)
+  2: move=> i _; rewrite (_: plus (F1 i) (F2 i) = \big[plus/zero]_(j : bool) F12 i j) //.
+rewrite bigA_distr_bigA big_mkord (partition_big
+  (fun i : {ffun I -> _} => inord #|[set x | i x]|)
+  (fun j : [finType of 'I_#|I|.+1] => true)) //=.
+{ eapply eq_big =>// i _.
+  rewrite (reindex (fun s : {set I} => [ffun x => x \in s])); last first.
+  { apply: onW_bij.
+    exists (fun f : {ffun I -> bool} => [set x | f x]).
+    by move=> s; apply/setP => v; rewrite inE ffunE.
+    by move=> f; apply/ffunP => v; rewrite ffunE inE. }
+  eapply eq_big.
+  { move=> s; apply/eqP/eqP.
+      move<-; rewrite -[#|s|](@inordK #|I|) ?ltnS ?max_card //.
+      by congr inord; apply: eq_card => v; rewrite inE ffunE.
+    move=> Hi; rewrite -[RHS]inord_val -{}Hi.
+    by congr inord; apply: eq_card => v; rewrite inE ffunE. }
+  by move=> j Hj; apply: eq_bigr => k Hk; rewrite /F12 ffunE. }
+rewrite (reindex (fun x : 'I_2 => (x : nat) == 1%N)); last first.
+  { apply: onW_bij.
+    exists (fun b : bool => inord (nat_of_bool b)).
+    by move=> [x Hx]; rewrite -[RHS]inord_val; case: x Hx =>// x Hx; case: x Hx.
+    by case; rewrite inordK. }
+rewrite 2!big_ord_recl big_ord0 /F12 /=.
+by rewrite Monoid.mulm1.
+Qed.
+
+Lemma bigID2 (R : Type) (I : finType) (J : {set I}) (F1 F2 : I -> R)
+    (idx : R) (op : Monoid.com_law idx) :
+  \big[op/idx]_(j in I) (if j \notin J then F1 j else F2 j) =
+  op (\big[op/idx]_(j in ~: J) F1 j) (\big[op/idx]_(j in J) F2 j).
+Proof.
+rewrite (bigID (mem (setC J)) predT); apply: congr2.
+by apply: eq_big =>// i /andP [H1 H2]; rewrite inE in_setC in H2; rewrite H2.
+apply: eq_big => [i|i /andP [H1 H2]] /=; first by rewrite inE negbK.
+by rewrite ifF //; apply: negbTE; rewrite inE in_setC in H2.
+Qed.
+
+Lemma bigcap_seq_const I (B : {set A}) (r : seq I) :
+  (0 < size r)%nat -> \bigcap_(i <- r) B = B.
+Proof.
+elim: r => [//|a r IHr] _; rewrite big_cons.
+case: r IHr => [|b r] IHr; first by rewrite big_nil setIT.
+by rewrite IHr // setIid.
+Qed.
+
+Lemma bigcap_ord_const n' (B : {set A}) :
+  \bigcap_(i < n'.+1) B = B.
+Proof. by rewrite bigcap_seq_const // /index_enum -enumT size_enum_ord. Qed.
+
+Lemma bigcap_const (I : eqType) (B : {set A}) (r : seq I) (p : pred I) :
+  (exists2 i : I, i \in r & p i) ->
+  \bigcap_(i <- r | p i) B = B.
+Proof.
+case=> i H1 H2; rewrite -big_filter bigcap_seq_const //.
+rewrite size_filter- has_count.
+by apply/hasP; exists i.
+Qed.
+
+Lemma m1powD k : k <> 0%nat -> (-1)^(k-1) = - (-1)^k.
+Proof.
+by case: k => [//|k _]; rewrite subn1 /= Ropp_mult_distr_l oppRK Rmult_1_l.
+Qed.
+
+Lemma bigsum_card_constE (I : finType) (B : pred I) x0 :
+  \rsum_(i in B) x0 = (INR #|B| * x0)%R.
+Proof. by rewrite big_const iter_addR. Qed.
+
+Lemma bigmul_constE (x0 : R) (k : nat) : \rprod_(i < k) x0 = (x0 ^ k)%R.
+Proof.
+rewrite big_const cardT size_enum_ord.
+elim: k => [//|k IHk].
+by rewrite /= IHk /= Rmult_comm.
+Qed.
+
+Lemma bigmul_card_constE (I : finType) (B : pred I) x0 : \rprod_(i in B) x0 = x0 ^ #|B|.
+Proof.
+rewrite big_const.
+elim: #|B| => [//|k IHk].
+by rewrite /= IHk /= Rmult_comm.
+Qed.
+
+(** [bigmul_m1pow] is the Reals counterpart of lemma [GRing.prodrN] *)
+Lemma bigmul_m1pow (I : finType) (p : pred I) (F : I -> R) :
+  \rprod_(i in p) - F i = (-1) ^ #|p| * \rprod_(i in p) F i.
+Proof.
+rewrite -bigmul_card_constE.
+apply: (big_rec3 (fun a b c => a = b * c)).
+{ by rewrite Rmult_1_l. }
+move=> i a b c Hi Habc; rewrite Habc; ring.
+Qed.
+
+Let SumIndCap (n : nat) (S : 'I_n -> {set A}) (k : nat) (x : A) :=
+  \rsum_(J in {set 'I_n} | #|J| == k) (Ind (\bigcap_(j in J) S j) x).
+
+Lemma Ind_bigcup_incl_excl (n : nat) (S : 'I_n -> {set A}) (x : A) :
+  Ind (\bigcup_(i < n) S i) x =
+  (\rsum_(1 <= k < n.+1) ((-1)^(k-1) * (SumIndCap S k x)))%R.
+Proof.
+case: n S => [|n] S; first by rewrite big_ord0 big_geq // Ind_set0.
+set Efull := \bigcup_(i < n.+1) S i.
+have Halg : \big[Rmult/R1]_(i < n.+1) (Ind Efull x - Ind (S i) x) = 0.
+  case Ex : (x \in Efull); last first.
+  { have /Ind_notinP Ex0 := Ex.
+    erewrite eq_bigr. (* to replace later with under *)
+      2: by rewrite Ex0.
+    have Ex00 : forall i : 'I_n.+1, Ind (S i) x = 0.
+      move=> i; apply/Ind_notinP.
+      by move/negbT: Ex; rewrite -!in_setC setC_bigcup; move/bigcapP; apply.
+    erewrite eq_bigr. (* to replace later with under *)
+      2: by move=> i _; rewrite Ex00.
+    rewrite Rminus_0_r.
+    by apply/bigmul_eq0; exists ord0. }
+  { rewrite /Efull in Ex.
+    have /bigcupP [i Hi Hi0] := Ex.
+    apply/bigmul_eq0; exists i =>//.
+    by rewrite /Efull (Ind_inP _ _ Ex) (Ind_inP _ _ Hi0) /Rminus Rplus_opp_r. }
+rewrite bigA_distr in Halg.
+do [erewrite eq_bigr; last by move=> k _; (* to replace later with under *)
+    erewrite eq_bigr; last by move=> J _; rewrite bigID2] in Halg.
+rewrite big_ltn //= in Halg.
+move/eqP in Halg; rewrite -> addR_eq0 in Halg; move/eqP in Halg.
+rewrite cardT size_enum_ord (big_pred1 set0) in Halg; last first.
+  by move=> i; rewrite pred1E [RHS]eq_sym; apply: cards_eq0.
+rewrite [in X in _ * X = _]big_pred0 in Halg; last by move=> i; rewrite inE.
+do [erewrite eq_bigl; (* to replace later with under *)
+  last by move=> j; rewrite !inE /negb /= ] in Halg.
+rewrite Rmult_1_r -Ind_bigcap bigcap_ord_const in Halg.
+rewrite {}Halg.
+rewrite (big_morph Ropp (id1 := R0) (op1 := Rplus)); first last.
+  by rewrite Ropp_0.
+  by move=> *; rewrite Ropp_plus_distr.
+rewrite big_nat [RHS]big_nat.
+apply: eq_bigr => i Hi; rewrite /SumIndCap /Efull.
+rewrite m1powD; last first.
+  by case/andP: Hi => Hi _ K0; rewrite K0 in Hi.
+rewrite -Ropp_mult_distr_l.
+rewrite [in RHS](big_morph _ (id1 := R0) (op1 := Rplus)); first last.
+  by rewrite Rmult_0_r.
+  by move=> *; rewrite Rmult_plus_distr_l.
+congr Ropp; apply: eq_bigr => j Hj.
+rewrite bigmul_m1pow (eqP Hj).
+rewrite (_ : ?[a] * ((-1)^i * ?[b]) = (-1)^i * (?a * ?b)); last by ring.
+congr Rmult.
+have [Hlt|Hn1] := ltnP i n.+1; last first.
+{ rewrite big1; last first.
+  { move=> k Hk; rewrite inE in Hk.
+    rewrite (_: j = [set: 'I_n.+1]) ?inE // in Hk.
+    apply/setP/subset_cardP =>//.
+    rewrite (eqP Hj) cardsT /= card_ord.
+    by apply/anti_leq/andP; split; first by case/andP: Hi =>//. }
+  by rewrite Rmult_1_l Ind_bigcap. }
+rewrite -!Ind_bigcap bigcap_const; last first.
+{ exists (odflt ord0 (pick [pred x | x \notin j])); first exact: mem_index_enum.
+  case: pickP; first by move=> y Hy; rewrite !inE -in_setC in Hy.
+  move=> /pred0P K; exfalso.
+  rewrite /pred0b in K.
+  have Hcard := cardsC j.
+  rewrite cardsE (eqP K) (eqP Hj) cardT size_enum_ord addn0 in Hcard.
+  by rewrite Hcard ltnn in Hlt. }
+rewrite -Ind_cap -/Efull.
+suff : \bigcap_(j0 in j) S j0 \subset Efull by move/setIidPr->.
+rewrite /Efull.
+pose i0 := odflt ord0 (pick (mem j)).
+have Hi0 : i0 \in j.
+{ rewrite /i0; case: pickP =>//.
+  move=> /pred0P K; exfalso.
+  rewrite /pred0b (eqP Hj) in K.
+    by rewrite (eqP K) /= in Hi. }
+apply: (subset_trans (bigcap_inf i0 Hi0)).
+exact: (bigcup_sup i0).
+Qed.
+
+Let SumPrCap (n : nat) (S : 'I_n -> {set A}) (k : nat) :=
+  \rsum_(J in {set 'I_n} | #|J| == k) Pr P (\bigcap_(j in J) S j).
+
+Lemma E_SumIndCap n (S : 'I_n -> {set A}) k :
+  `E (rv (SumIndCap S k)) = SumPrCap S k.
+Proof.
+rewrite /SumIndCap /SumPrCap E_rsum; apply: eq_bigr => i Hi.
+by rewrite E_Ind.
+Qed.
+
+Theorem Pr_bigcup_incl_excl n (S : 'I_n -> {set A}) :
+  Pr P (\bigcup_(i < n) S i) =
+  \big[Rplus/0%R]_(1 <= k < n.+1) ((-1)^(k-1) * SumPrCap S k).
+Proof.
+rewrite -E_Ind ExE /=.
+erewrite eq_bigr. (* to replace later with under *)
+  2: by move=> ? _; rewrite /= Ind_bigcup_incl_excl.
+simpl.
+erewrite eq_bigr. (* to replace later with under *)
+  2: by move=> a Ha; rewrite big_distrl.
+rewrite exchange_big /=.
+apply: eq_bigr => i _.
+by rewrite -E_SumIndCap -E_scalel ExE.
+Qed.
+
+End probability_inclusion_exclusion.
+
 Section markov_inequality.
 
 Variable A : finType.
@@ -1000,6 +1332,8 @@ Qed.
 End markov_inequality.
 
 Notation "'Pr[' X '>=' r ']'" := (pr_geq X r) : proba_scope.
+
+(** * Variance *)
 
 Section variance_definition.
 

--- a/ssrR.v
+++ b/ssrR.v
@@ -71,6 +71,9 @@ Proof. move=> a b c; by field. Qed.
 Lemma addRK (a : R) : cancel (Rplus^~ a) (Rminus^~ a).
 Proof. move=> b; by field. Qed.
 
+Lemma addRN r : r + - r = 0.
+Proof. exact: Rplus_opp_r r. Qed.
+
 Definition subR0 : right_id 0 Rminus := Rminus_0_r.
 Definition sub0R := Rminus_0_l.
 
@@ -85,6 +88,9 @@ Proof.
 apply/idP/idP => [|/eqP ->]; last by rewrite subRR.
 by move/eqP/Rminus_diag_uniq => ->.
 Qed.
+
+Lemma subR0_eq x y : x - y = 0 -> x = y.
+Proof. exact: Rminus_diag_uniq x y. Qed.
 
 Lemma subR_eq x y z : (x - z == y) = (x == y + z).
 Proof.
@@ -171,6 +177,23 @@ Lemma oppR_eq0 x : (- x == 0) = (x == 0).
 Proof.
 apply/idP/idP => [|/eqP ->]; last by rewrite oppR0.
 apply: contraTT; by move/eqP/Ropp_neq_0_compat/eqP.
+Qed.
+
+Lemma addR_eq0 x y : (x + y == 0) = (x == - y).
+Proof. by rewrite -[y in LHS]oppRK subR_eq0. Qed.
+
+Lemma eqR_opp x y : (- x == - y) = (x == y).
+Proof.
+apply/eqP/eqP.
+{ by move=> Hopp; rewrite -[LHS]oppRK -[RHS]oppRK Hopp. }
+by move->.
+Qed.
+
+Lemma eqR_oppLR x y : (- x == y) = (x == - y).
+Proof.
+apply/eqP/eqP.
+{ by move<-; rewrite oppRK. }
+by move->; rewrite oppRK.
 Qed.
 
 Lemma oppR_ge0 x : x <= 0 -> 0 <= - x.


### PR DESCRIPTION
Hi @affeldt-aist :)
As I had promised a few months ago, I'm opening this PR to share some code I recently developed in the [Random Boolean Games](https://sourcesup.renater.fr/coq-bool-games/) project, namely the **formula of inclusion-exclusion**: the corresponding theorem is named `Pr_bigcup_incl_excl` in file `proba.v`.

I updated the `OUTLINE` comment at the beginning of the file, but some cosmetic changes might be necessary to integrate this proof better in infotheo (basically, moving a few lemmas to another file?)

Thus, feel free to request some modifications, or to add some commits directly in my branch (because I checked the box ["Allow edits from maintainers"](https://blog.github.com/2016-09-07-improving-collaboration-with-forks/))

Just FYI, there were 9 occurrences in the proof that relied on the `under` tactic I am currently reimplementing from scratch with @gares's help, so I tweaked the script to make this PR «`under`-free» :) (but I'll be able to propose another PR later on when `under` 2.0 will be ready to make these 9 parts of the script more legible...)

Kind regards, Erik