### PR TITLE
fix compilation with MathComp 1.9.0 and Coq 8.10+beta1

### DIFF
--- a/information_theory/kraft.v
+++ b/information_theory/kraft.v
@@ -300,7 +300,7 @@ Record code_set := CodeSet {
 }.
 
 Definition mem_code_set (C : code_set) := fun x => x \in codeset C.
-Canonical code_set_predType := Eval hnf in @mkPredType _ code_set mem_code_set.
+Canonical code_set_predType := Eval hnf in @PredType _ code_set mem_code_set.
 
 Definition sort_sizes (C : code_set) : seq nat := sort leq (map size C).
 

--- a/lib/ssr_ext.v
+++ b/lib/ssr_ext.v
@@ -688,7 +688,7 @@ Variable n : nat.
 Definition bseq_eqMixin (T : eqType) := Eval hnf in [eqMixin of n.-bseq T by <:].
 Canonical bseq_eqType (T : eqType) := Eval hnf in EqType (n.-bseq T) (bseq_eqMixin T).
 Canonical bseq_predType (T : eqType) :=
-  Eval hnf in mkPredType (fun t : n.-bseq T => mem_seq t). (* TODO: warning *)
+  Eval hnf in PredType (fun t : n.-bseq T => mem_seq t). (* TODO: warning *)
 Definition bseq_choiceMixin (T : choiceType) := [choiceMixin of n.-bseq T by <:].
 Canonical bseq_choiceType (T : choiceType) :=
   Eval hnf in ChoiceType (n.-bseq T) (bseq_choiceMixin T).

--- a/probability/convex.v
+++ b/probability/convex.v
@@ -878,7 +878,7 @@ Section cset_canonical.
 Variable (A : convType).
 Canonical cset_subType := [subType for @CSet.car A].
 Canonical cset_predType :=
-  Eval hnf in mkPredType (fun t : convex_set A => (fun x => x \in CSet.car t)).
+  Eval hnf in PredType (fun t : convex_set A => (fun x => x \in CSet.car t)).
 Definition cset_eqMixin := Eval hnf in [eqMixin of convex_set A by <:].
 Canonical cset_eqType := Eval hnf in EqType (convex_set A) cset_eqMixin.
 End cset_canonical.

--- a/probability/proba.v
+++ b/probability/proba.v
@@ -555,7 +555,8 @@ Module AddDist.
 Section def.
 Variables (n m : nat) (d1 : {dist 'I_n}) (d2 : {dist 'I_m}) (p : prob).
 Definition f := [ffun i : 'I_(n + m) =>
-  match fintype.split i with inl a => p * d1 a | inr a => p.~ * d2 a end].
+  let si := fintype.split i in
+  match si with inl a => (p * d1 a) | inr a => p.~ * d2 a end].
 Lemma f0 i : 0 <= f i.
 Proof.
 rewrite /f ffunE; case: splitP => a _.


### PR DESCRIPTION
We're trying to build a corpus ("snapshot") of MathComp-related projects that work with MathComp 1.9.0 and Coq 8.10+beta1 to use for proof engineering research, and we want to include infotheo. To this end, here is a minimal set of changes to make the project compile with these MathComp and Coq versions.