### PR TITLE
lighter notation for marginal aposteriori probability

### DIFF
--- a/ecc_classic/decoding.v
+++ b/ecc_classic/decoding.v
@@ -312,7 +312,7 @@ Variable P : {dist 'rV[A]_n}.
 
 Definition MAP_decoding := forall y (Hy : receivable W P y),
   exists m, dec y = Some m /\
-    P `^^ W , Hy (m | y) = \rmax_(m in C) (P `^^ W , Hy (m | y)).
+    P `^^ W (m | Hy) = \rmax_(m in C) (P `^^ W (m | Hy)).
 
 End MAP_decoding.
 
@@ -378,6 +378,6 @@ Definition MPM_condition := let P := `U C_not_empty in
   forall y (Hy : receivable W P y),
   forall x, dec y = Some x ->
   forall n0,
-    P '_ n0 `^^ W , Hy ((enc x) ``_ n0 | y) = \rmax_(b in 'F_2) P '_ n0 `^^ W , Hy (b | y).
+    P '_ n0 `^^ W ((enc x) ``_ n0 | Hy) = \rmax_(b in 'F_2) P '_ n0 `^^ W (b | Hy).
 
 End MPM_condition.

--- a/ecc_modern/checksum.v
+++ b/ecc_modern/checksum.v
@@ -181,8 +181,9 @@ Local Open Scope proba_scope.
 Hypothesis Hy : receivable W (`U HC) y.
 
 Lemma post_proba_uniform_checksubsum (x : 'rV['F_2]_n) :
-  (`U HC) `^^ W, Hy (x | y) =
-    (PosteriorProbability.Kppu W [set cw in C] y * (\prod_m0 (\delta ('V m0) x))%:R * W ``(y | x))%R.
+  (`U HC) `^^ W (x | Hy) =
+    (PosteriorProbability.Kppu W [set cw in C] y *
+     (\prod_m0 (\delta ('V m0) x))%:R * W ``(y | x))%R.
 Proof.
 rewrite PosteriorProbability.uniform_kernel; congr (_ * _ * _)%R.
 by rewrite big_morph_natRM checksubsum_in_kernel inE mem_kernel_syndrome0.

--- a/ecc_modern/ldpc.v
+++ b/ecc_modern/ldpc.v
@@ -85,7 +85,7 @@ Variable a' : A.
 Hypothesis Ha' : receivable (BSC.c card_A p_01) (P `^ 1) (\row_(i < 1) a').
 
 Lemma bsc_post (a : A) :
-  (P `^ 1) `^^ (BSC.c card_A p_01) , Ha' (\row_(i < 1) a | \row_(i < 1) a') =
+  (P `^ 1) `^^ (BSC.c card_A p_01) (\row_(i < 1) a | Ha') =
   (if a == a' then 1 - p else p)%R.
 Proof.
 rewrite PosteriorProbability.dE /= /PosteriorProbability.den /=.
@@ -426,7 +426,7 @@ Let C := kernel H.
 Let C_not_empty := Lcode0.not_empty C.
 Hypothesis Hy : receivable W (`U C_not_empty) y.
 
-(*Let g := fun n0 (x : 'F_2) => (`U C_not_empty) '_ n0 `^^ W , Hy (x | y).*)
+(*Let g := fun n0 (x : 'F_2) => (`U C_not_empty) '_ n0 `^^ W (x | Hy).*)
 
 Local Notation "''V'" := (Vnext H).
 Local Notation "''F'" := (Fnext H).
@@ -443,7 +443,7 @@ Local Open Scope R_scope.
 
 Lemma estimation_correctness (d : 'rV_n) n0 :
   let b := d ``_ n0 in let P := `U C_not_empty in
-  P '_ n0 `^^ W , Hy (b | y) =
+  P '_ n0 `^^ W (b | Hy) =
     MarginalPostProbability.Kmpp Hy * PosteriorProbability.Kppu W [set cw in C] y *
     W `(y ``_ n0 | b) * \prod_(m0 in 'F n0) alpha m0 n0 d.
 Proof.

--- a/ecc_modern/ldpc_algo.v
+++ b/ecc_modern/ldpc_algo.v
@@ -315,7 +315,7 @@ Let C := kernel H.
 Let C_not_empty := Lcode0.not_empty C.
 Hypothesis Hy : receivable W (`U C_not_empty) y.
 Definition esti_spec n0 (x : 'rV_n) :=
-  `U C_not_empty '_ n0 `^^ W, Hy (x ``_ n0 | y).
+  `U C_not_empty '_ n0 `^^ W (x ``_ n0 | Hy).
 
 Definition estimation_spec := uniq (unzip1 estimations) /\
   forall n0, (inr n0, p01 (esti_spec n0) n0) \in estimations.

--- a/information_theory/pproba.v
+++ b/information_theory/pproba.v
@@ -17,10 +17,10 @@ Require Import cproba.
 - Section marginal_post_proba_prop.
 *)
 
-Reserved Notation "P '`^^' W ',' H '(' x '|' y ')'" (at level 10,
-  W, y, x, H at next level).
-Reserved Notation "P ''_' n0 '`^^' W ',' H '(' a '|' y ')'" (at level 10,
-  n0, W, H, a, y at next level).
+Reserved Notation "P '`^^' W '(' x '|' Hy ')'" (at level 10,
+  W, x, Hy at next level).
+Reserved Notation "P ''_' n0 '`^^' W '(' a '|' Hy ')'" (at level 10,
+  n0, W, a, Hy at next level).
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -116,14 +116,14 @@ Definition d : {dist 'rV[A]_n} := locked (makeDist f0 f1).
 Lemma dE x : d x = P x * W ``(y | x) / den.
 Proof. by rewrite /d; unlock; rewrite ffunE. Qed.
 End def.
-Local Notation "P '`^^' W ',' H '(' x '|' y ')'" := (@d _ _ W _ P y H x).
+Local Notation "P '`^^' W '(' x '|' Hy ')'" := (@d _ _ W _ P _ Hy x).
 
 (* relation with channel-based information-theoretic definitions *)
 Section chap2.
 Variables (A B : finType) (W : `Ch(A, B)) (n : nat) (P : {dist 'rV[A]_n}).
 Local Open Scope channel_scope.
 Lemma ppE (x : 'rV[A]_n) (y : 'rV[B]_n) (Hy : receivable W P y) :
-  P `^^ W , Hy (x | y) = \Pr_(`J(P, W ``^ n))[[set x]|[set y]].
+  P `^^ W (x | Hy) = \Pr_(`J(P, W ``^ n))[[set x]|[set y]].
 Proof.
 rewrite dE /cPr setX1 2!Pr_set1 JointDistChan.dE /=; congr (_ / _).
 rewrite Bivar.sndE /=; apply eq_bigr => x' _; by rewrite JointDistChan.dE /= mulRC.
@@ -140,11 +140,11 @@ Hypothesis Hy : receivable W (`U HC) y.
 Definition Kppu := / \sum_(c in C) W ``(y | c).
 
 Lemma uniformEF (x : 'rV[A]_n) : x \notin C ->
-  (`U HC) `^^ W, Hy (x | y) = 0.
+  (`U HC) `^^ W (x | Hy) = 0.
 Proof. move=> xC; by rewrite dE UniformSupport.dEN // /Rdiv !mul0R. Qed.
 
 Lemma uniformET (x : 'rV[A]_n) : x \in C ->
-  (`U HC) `^^ W, Hy (x | y) = Kppu * W ``(y | x).
+  (`U HC) `^^ W (x | Hy) = Kppu * W ``(y | x).
 Proof.
 move=> Ht.
 rewrite dE UniformSupport.dET // mulRC {1}/Rdiv -mulRA [in RHS]mulRC; congr (_ * _).
@@ -162,7 +162,7 @@ by apply/eqP; rewrite -not_receivable_uniformE Hy.
 Qed.
 
 Lemma uniform_kernel (x : 'rV[A]_n) :
-  (`U HC) `^^ W, Hy (x | y) = (Kppu * INR (x \in C) * W ``(y | x))%R.
+  (`U HC) `^^ W (x | Hy) = (Kppu * INR (x \in C) * W ``(y | x))%R.
 Proof.
 case/boolP : (x \in C) => xC.
 - by rewrite uniformET // ?inE // mulR1.
@@ -172,8 +172,8 @@ Qed.
 End prop.
 End PosteriorProbability.
 
-Notation "P '`^^' W ',' H '(' x '|' y ')'" :=
-  (@PosteriorProbability.d _ _ W _ P y H x) : proba_scope.
+Notation "P '`^^' W '(' x '|' Hy ')'" :=
+  (@PosteriorProbability.d _ _ W _ P _ Hy x) : proba_scope.
 
 Local Open Scope vec_ext_scope.
 
@@ -183,7 +183,7 @@ Variables (A B : finType) (W : `Ch(A, B)) (n : nat) (P : {dist 'rV[A]_n}).
 Variable y : 'rV[B]_n.
 Hypothesis Hy : receivable W P y.
 
-Let f' := fun x : 'rV_n => P `^^ W, Hy (x | y).
+Let f' := fun x : 'rV_n => P `^^ W (x | Hy).
 
 Definition Kmpp : R := / \sum_(t in 'rV_n) f' t.
 
@@ -224,8 +224,8 @@ Qed.
 Definition d i : dist A := makeDist (f0 i) (f1 i).
 
 End def.
-Local Notation "P ''_' n0 '`^^' W ',' Hy '(' a '|' y ')'" :=
-  (@d _ _ W _ P y Hy n0 a).
+Local Notation "P ''_' n0 '`^^' W '(' a '|' Hy ')'" :=
+  (@d _ _ W _ P _ Hy n0 a).
 Section prop.
 Variables (A B : finType) (W : `Ch(A, B)).
 Variables (n : nat) (C : {set 'rV[A]_n}).
@@ -235,12 +235,12 @@ Variable y : 'rV[B]_n.
 Hypothesis Hy : receivable W (`U HC) y.
 
 Lemma probaE b n0 :
-  (`U HC) '_ n0 `^^ W, Hy (b | y) =
-  Kmpp Hy * (\sum_(t in 'rV_n | t ``_ n0 == b) (`U HC) `^^ W, Hy (t | y)).
+  (`U HC) '_ n0 `^^ W (b | Hy) =
+  Kmpp Hy * (\sum_(t in 'rV_n | t ``_ n0 == b) (`U HC) `^^ W (t | Hy)).
 Proof. by rewrite ffunE. Qed.
 
 End prop.
 End MarginalPostProbability.
 
-Notation "P ''_' n0 '`^^' W ',' H '(' a '|' y ')'" :=
-  (@MarginalPostProbability.d _ _ W _ P y H n0 a) : proba_scope.
+Notation "P ''_' n0 '`^^' W '(' a '|' Hy ')'" :=
+  (@MarginalPostProbability.d _ _ W _ P _ Hy n0 a) : proba_scope.


### PR DESCRIPTION
The idea is to just drop `y`, since it is implicit in `Hy`.
Note that in theory we could also drop `P` and `W` since they also appear in `Hy`, but this might be confusing.

```coq
Reserved Notation "P '`^^' W '(' x '|' Hy ')'".
Reserved Notation "P ''_' n0 '`^^' W '(' a '|' Hy ')'".

Lemma ppE (x : 'rV[A]_n) (y : 'rV[B]_n) (Hy : receivable W P y) :
  P `^^ W (x | Hy) = \Pr_(`J(P, W ``^ n))[[set x]|[set y]].
```