### PR TITLE
avoid Program Definition at bseq0; canonicize bseq0

### DIFF
--- a/lib/ssr_ext.v
+++ b/lib/ssr_ext.v
@@ -682,7 +682,8 @@ End bseq_def.
 
 Notation "n .-bseq" := (bseq_of n) : type_scope.
 
-Program Definition bseq0 n T : n.-bseq T := @Bseq n T [::] _.
+Definition bseq0 n T : n.-bseq T := @Bseq n T [::] (leq0n _).
+Canonical bseq0.
 
 Definition bseq_of_tuple n T (t : seq T) : n.-bseq T :=
   match Bool.bool_dec (size t <= n) true with


### PR DESCRIPTION
The definition of bseq0 in master uses Program Definition, which is however unnecessary and complicates the term.
This commit avoids it. 

Additionally bseq0 is declared Canonical to allow the expression [bseq of [::]].