### PR TITLE
compatibility with MathComp 1.12

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'mathcomp/mathcomp:1.11.0-coq-8.11'
-          - 'mathcomp/mathcomp:1.11.0-coq-8.12'
+          - 'mathcomp/mathcomp:1.12.0-coq-8.11'
+          - 'mathcomp/mathcomp:1.12.0-coq-8.12'
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ env:
   - NJOBS="2"
   - CONTRIB_NAME="infotheo"
   matrix:
-  - DOCKERIMAGE="mathcomp/mathcomp:1.11.0-coq-8.11"
-  - DOCKERIMAGE="mathcomp/mathcomp:1.11.0-coq-8.12"
+  - DOCKERIMAGE="mathcomp/mathcomp:1.12.0-coq-8.11"
+  - DOCKERIMAGE="mathcomp/mathcomp:1.12.0-coq-8.12"
 
 install: |
   # Prepare the COQ container

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ information theory, and linear error-correcting codes.
 - License: [LGPL-2.1-or-later](LICENSE)
 - Compatible Coq versions: Coq 8.11 to 8.12
 - Additional dependencies:
-  - [MathComp ssreflect 1.11](https://math-comp.github.io)
-  - [MathComp fingroup 1.11](https://math-comp.github.io)
-  - [MathComp algebra 1.11](https://math-comp.github.io)
-  - [MathComp solvable 1.11](https://math-comp.github.io)
-  - [MathComp field 1.11](https://math-comp.github.io)
+  - [MathComp ssreflect 1.12](https://math-comp.github.io)
+  - [MathComp fingroup 1.12](https://math-comp.github.io)
+  - [MathComp algebra 1.12](https://math-comp.github.io)
+  - [MathComp solvable 1.12](https://math-comp.github.io)
+  - [MathComp field 1.12](https://math-comp.github.io)
   - [MathComp analysis 0.3.4](https://github.com/math-comp/analysis)
 - Coq namespace: `infotheo`
 - Related publication(s):

--- a/coq-infotheo.opam
+++ b/coq-infotheo.opam
@@ -3,7 +3,6 @@
 
 opam-version: "2.0"
 maintainer: "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
-version: "dev"
 
 homepage: "https://github.com/affeldt-aist/infotheo"
 dev-repo: "git+https://github.com/affeldt-aist/infotheo.git"
@@ -18,16 +17,16 @@ information theory, and linear error-correcting codes."""
 build: [
     [make "-j%{jobs}%" ]
     [make "-C" "extraction" "tests"] {with-test}
-]
+  ]
 install: [make "install"]
 depends: [
   "coq" { (>= "8.11" & < "8.13~") | (= "dev") }
-  "coq-mathcomp-ssreflect" { (>= "1.11.0" & < "1.12~") }
-  "coq-mathcomp-fingroup" { (>= "1.11.0" & < "1.12~") }
-  "coq-mathcomp-algebra" { (>= "1.11.0" & < "1.12~") }
-  "coq-mathcomp-solvable" { (>= "1.11.0" & < "1.12~") }
-  "coq-mathcomp-field" { (>= "1.11.0" & < "1.12~") }
-  "coq-mathcomp-analysis" { (= "0.3.4") }
+  "coq-mathcomp-ssreflect" { (>= "1.12.0" & < "1.13~") }
+  "coq-mathcomp-fingroup" { (>= "1.12.0" & < "1.13~") }
+  "coq-mathcomp-algebra" { (>= "1.12.0" & < "1.13~") }
+  "coq-mathcomp-solvable" { (>= "1.12.0" & < "1.13~") }
+  "coq-mathcomp-field" { (>= "1.12.0" & < "1.13~") }
+  "coq-mathcomp-analysis" { (>= "0.3.4") }
 ]
 
 tags: [

--- a/ecc_classic/bch.v
+++ b/ecc_classic/bch.v
@@ -346,7 +346,7 @@ rewrite BCH_det_mlinear det_vander mulf_neq0 //.
   rewrite prodf_seq_neq0 /=; apply/allP => /= k _.
   apply/implyP => jk; rewrite !mxE /= !expr1 subr_eq0.
   apply/negP => /eqP; move: (proj1 a_neq0) => /(_ (f k) (f j)).
-  rewrite 2!ffunE => akj /akj/Hinj; exact/eqP/negbT/gtn_eqF.
+  by rewrite 2!ffunE => akj /akj/Hinj; exact/eqP/negbT/gtn_eqF.
 Qed.
 
 (** parity-check matrix of a binary (n, k) code capable ot correcting
@@ -523,7 +523,7 @@ rewrite mxE -mulrA; congr (_ * _).
   apply/eq_big.
     by move=> j; rewrite in_setD1 andbC.
   move=> j _; by rewrite mxE.
-by rewrite -polyC_mul -exprSr -exprM mulnC.
+by rewrite -polyCM -exprSr -exprM mulnC.
 Qed.
 
 Hypothesis (tn : t.*2 < n).
@@ -674,7 +674,7 @@ set x' := map_mx _ _.
 have [M HM] : exists M, `[ 'X * rVpoly x' ]_ n = 'X * rVpoly x' + M * ('X^n - 1).
   exists (- ('X * rVpoly x') %/ ('X^n - 1)).
   move/eqP: (divp_eq ('X * rVpoly x') ('X^n - 1)); rewrite addrC -subr_eq => /eqP <-.
-  by rewrite divp_opp mulNr.
+  by rewrite divpN mulNr.
 rewrite HM /fdcoor poly_rV_K //; last first.
   rewrite -HM.
   move: (ltn_modp ('X * rVpoly x') ('X^n - 1)).

--- a/ecc_classic/cyclic_code.v
+++ b/ecc_classic/cyclic_code.v
@@ -382,7 +382,7 @@ have -> : `[ \sum_(i < size p) (p`_i *: ('X^i * c)) ]_n  =
   by rewrite (big_morph (id1 := 0) _ (@morph_modp _ _)) // mod0p.
 have -> : \sum_(i < size p) `[ p`_i *: ('X^i * c) ]_n  =
           \sum_(i < size p) (p`_i *: `[ 'X^i * c ]_ n ).
-  apply eq_bigr => k _; by rewrite modp_scalel.
+  apply eq_bigr => k _; by rewrite modpZl.
 apply Lcode0.mem_poly_rV => j.
 rewrite linearZ /= Lcode0.sclosed //; by apply shift_codeword.
 Qed.
@@ -400,9 +400,9 @@ have -> : r = `[ r ]_n.
   by rewrite size_Xn_sub_1 // ltnS.
 rewrite (_ : r = rVpoly p - rVpoly p %/ c * c); last first.
   by rewrite {1}Hdivp_g addrAC subrr add0r.
-rewrite modp_add linearD /=.
+rewrite modpD linearD /=.
 have -> : `[ rVpoly p ]_n = rVpoly p.
-  rewrite modp_small // size_Xn_sub_1 // ltnS; by apply: size_poly.
+  by rewrite modp_small // size_Xn_sub_1 // ltnS size_poly.
 rewrite rVpolyK; apply Lcode0.aclosed => //.
 by rewrite -mulNr shift_linearity_codeword.
 Qed.
@@ -472,7 +472,7 @@ have size_rem : size (p %% rVpoly g) < size (rVpoly g).
 have rem_n : size (p %% rVpoly g) <= n.
   by rewrite ltnW //; apply/(leq_trans size_rem)/(size_is_cgen Hg).
 rewrite modp_small; last by rewrite size_Xn_sub_1.
-rewrite modp_add modp_opp => pmodg.
+rewrite modpD modpN => pmodg.
 have rem_in_C : poly_rV (p %% rVpoly g) \in C.
   rewrite pmodg linearD /= (proj2 (Lcode0.aclosed C)) // linearN /= Lcode0.oclosed //.
   apply/shift_linearity_codeword => //.
@@ -582,7 +582,7 @@ split.
   by rewrite inE linear0 dvdp0.
 move=> k a b; rewrite !inE => ga gb.
 case/boolP : (k == 0) => [/eqP ->|k0]; first by rewrite scale0r add0r.
-by rewrite linearD linearZ /= dvdp_addr // dvdp_scaler.
+by rewrite linearD linearZ /= dvdp_addr // dvdpZr.
 Qed.
 
 Lemma divides_Xn_sub_1_is_cyclic (g : {poly F}) : g %| 'X^n - 1 ->

--- a/ecc_classic/grs.v
+++ b/ecc_classic/grs.v
@@ -85,12 +85,12 @@ rewrite (eq_bigr (fun i : 'I_r => 'X^i * (syndrome_coord_supp i y)%:P)); last fi
 rewrite /syndrome_coord_supp.
 rewrite (eq_bigr (fun i : 'I_r => (\sum_(j in supp y) 'X^i * (y ``_ j * b ``_ j * a ``_ j ^+ i)%:P))); last first.
   move=> i _.
-  by rewrite -big_distrr /= (big_morph (id1:=0) (fun x => x%:P) (@polyC_add _)).
+  by rewrite -big_distrr /= (big_morph (id1:=0) (fun x => x%:P) (@polyCD _)).
 rewrite exchange_big /=.
 rewrite (eq_bigr (fun j => (y ``_ j * b ``_ j)%:P * \sum_(l < r) ((a ``_ j ^+ l)%:P * 'X^l))) //.
 move=> i isupp.
 rewrite !big_distrr /=; apply eq_bigr => j _.
-by rewrite mulrC mulrA polyC_mul.
+by rewrite mulrC mulrA polyCM.
 Qed.
 
 Lemma syndromep_syndrome r y : (syndrome r y == 0) = (syndromep r y == 0).
@@ -224,7 +224,7 @@ rewrite /GRS_mod big_distrl /= /Omega /erreval -big_split /=.
 rewrite GRS.syndomepE big_distrr /=.
 apply eq_bigr => i iy.
 rewrite -3!scalerAl -scalerA -scalerDr.
-rewrite polyC_mul -!mulrA mulrCA !mulrA mul_polyC -!scalerAl; congr (_ *: _).
+rewrite polyCM -!mulrA mulrCA !mulrA mul_polyC -!scalerAl; congr (_ *: _).
 rewrite /Sigma /errloc (bigD1 i) //= mulrC -!mulrA mulrBl mul1r.
 set x := (X in _ * X = _).
 rewrite (_ : x = (b ``_ i)%:P * (1 - (a ``_ i ^+ r)%:P * 'X^r)); last first.
@@ -239,7 +239,7 @@ rewrite (_ : x = (b ``_ i)%:P * (1 - (a ``_ i ^+ r)%:P * 'X^r)); last first.
     apply/eqP; rewrite subr_eq0; apply/eqP.
     apply eq_bigr => j _.
     rewrite -!scalerAl mulrCA -exprS !scalerAl; congr (_ * _).
-    by rewrite -mul_polyC -polyC_mul -exprS.
+    by rewrite -mul_polyC -polyCM -exprS.
   by rewrite -mulrCA -scalerAl -exprS 2!mul_polyC scalerA -exprSr.
 rewrite mulrA mulrBr mulr1 mulrC -mul_polyC; congr (_ * _ + _).
  apply/eq_bigl => j; by rewrite in_setD1 andbC.

--- a/ecc_classic/hamming_code.v
+++ b/ecc_classic/hamming_code.v
@@ -523,7 +523,7 @@ destruct (ids1 j) => /= Hij.
 have Hlti : i < size idsA by rewrite size_idsA.
 move: (mem_nth 0 Hlti).
 rewrite Hij => Hi.
-move: (mem_imset (fun i => col i (Hamming.PCM m)) Hi).
+move: (imset_f (fun i => col i (Hamming.PCM m)) Hi).
 rewrite /idsA e.
 case/imsetP => y Hy Hy'.
 rewrite mem_filter -Hy' in Hy.

--- a/ecc_classic/poly_decoding.v
+++ b/ecc_classic/poly_decoding.v
@@ -41,7 +41,7 @@ move=> ij H0.
 have H : forall n, lead_coef 'X^n \is a GRing.unit
   by move=> ??; rewrite lead_coefXn GRing.unitr1.
 rewrite (Pdiv.IdomainUnit.divp_eq (H R j) p).
-rewrite (Pdiv.IdomainUnit.modp_add (H R i)).
+rewrite (Pdiv.IdomainUnit.modpD (H R i)).
 rewrite modp_eq0; last by rewrite dvdp_mull // dvdp_exp2l.
 by rewrite add0r -(Pdiv.IdomainUnit.divp_eq (H R j) p) modp_small // size_polyXn.
 Qed.
@@ -116,7 +116,7 @@ rewrite /errloc (big_setD1 f) //= derivM IH; last first.
   move: (cardsD1 f E); rewrite Hf /= add1n Em; by case.
 rewrite derivB derivC sub0r linearZ /= derivX.
 rewrite [in RHS](big_setD1 f) //=; congr (_ + _).
-  by rewrite alg_polyC -mul_polyC polyC_opp.
+  by rewrite alg_polyC -mul_polyC polyCN.
 rewrite big_distrr /=; apply eq_bigr => i Hi.
 rewrite mulrC -!mul_polyC -mulrA; congr (_ * _).
 rewrite [in RHS](big_setD1 f) //=; last first.
@@ -131,9 +131,9 @@ Proof.
 move=> a0.
 rewrite /errloc (eq_bigr (fun i : 'I_n => (- a ``_ i)%:P * ('X - (a ``_ i)^-1%:P))).
   by rewrite big_split.
-move=> i Hi.
-rewrite -polyC_opp mulrDr -polyC_mul mulrNN divff //.
-by rewrite polyC1 -(addrC 1) polyC_opp mulNr mul_polyC.
+move=> i iE.
+rewrite -polyCN mulrDr -polyCM mulrNN divff //.
+by rewrite polyC1 -(addrC 1) polyCN mulNr mul_polyC.
 Qed.
 
 Lemma errloc_neq0 a E : errloc a E != 0.
@@ -160,7 +160,7 @@ move=> Ha; apply/idP/idP => H.
   apply/rootP.
   rewrite (decomp_errloc _ (proj2 Ha)) ?unitfE //= rootM negb_or.
   apply/andP; split.
-    rewrite -(@big_morph _ _ _ _ _ 1 _ (@polyC_mul F)) // rootC prodf_seq_neq0 /=.
+    rewrite -(@big_morph _ _ _ _ _ 1 _ (@polyCM F)) // rootC prodf_seq_neq0 /=.
     apply/allP => n0 _.
     apply/implyP => _; by rewrite oppr_eq0 (proj2 Ha).
   move: (root_prod_XsubC [seq (a ``_ x)^-1 | x : 'I_n <- enum E] (a ``_ i)^-1).
@@ -257,7 +257,7 @@ suff no_root_p : forall x, root p x -> False.
   move : p_sigma; rewrite (decomp_errloc _ (proj2 Ha)) //.
   move/(dvdp_mull (\prod_(i in supp E) (- a ``_ i)^-1%:P)).
   rewrite mulrA -big_split /= (eq_bigr (fun=> 1%:P)); last first.
-    move=> i _; by rewrite -polyC_mul mulVr // unitrN unitfE (proj2 Ha).
+    move=> i _; by rewrite -polyCM mulVr // unitrN unitfE (proj2 Ha).
   rewrite big1 // mul1r -big_filter; case/dvdp_prod_XsubC => bs.
   set mask_bs := mask bs _.
   case size_bsE : (size mask_bs).

--- a/ecc_classic/reed_solomon.v
+++ b/ecc_classic/reed_solomon.v
@@ -300,8 +300,8 @@ rewrite -!scalerAl; congr (_ *: _ ).
 rewrite -mulrA; congr (_ * _).
   apply eq_big.
     by move=> j; rewrite in_setD1 andbC.
-  move=> j; by rewrite mxE.
-by rewrite mxE -polyC_mul -exprSr -exprM mulnC.
+  by move=> j; rewrite mxE.
+by rewrite mxE -polyCM -exprSr -exprM mulnC.
 Qed.
 
 Lemma RS_key_equation y :

--- a/ecc_modern/degree_profile.v
+++ b/ecc_modern/degree_profile.v
@@ -395,7 +395,7 @@ elim: l k x => [|l IH] k x.
 rewrite (tree_node_children x).
 rewrite -(@finseqs_deg n l k (tree_enum l (negk k))); last by [].
 rewrite {IH} /=.
-f_equal.
+congr addn.
 - rewrite eqtype.inj_eq //.
   by apply Node_inj.
 - rewrite count_map.
@@ -662,7 +662,7 @@ case: l => [|l].
 rewrite doubleS -addn1 /=.
 rewrite big_cons add0r big_map big_flatten.
 rewrite big_map /=.
-rewrite (iota_addl 1 0) big_map.
+rewrite (iotaDl 1 0) big_map.
 rewrite /tree_dist_children.
 transitivity (\sum_(0 <= d < tw) (LR kv)`_d); last first.
   have: (size (LR kv) <= tw)%nat.
@@ -854,14 +854,10 @@ symmetry.
 apply/imsetP.
 case: ifPn => Hyx.
   rewrite -(@can2_in_imset_pre _ _ (enum_rank_in (Hxp _ Hyx))).
-      esplit.
-        by apply mem_imset, Hyx.
-      rewrite enum_rankK_in //.
-      by apply Hxp.
-    move=> z Hz.
-    by apply (enum_rankK_in _ (Hxp _ Hz)).
-  move=> z Hz.
-  by rewrite enum_valK_in.
+      esplit; first exact/imset_f/Hyx.
+      by rewrite enum_rankK_in // Hxp.
+    by move=> z Hz; exact: (enum_rankK_in _ (Hxp _ Hz)).
+  by move=> z Hz; rewrite enum_valK_in.
 move=> [z Hz Hzy].
 rewrite /preimset inE in Hz.
 by rewrite Hzy Hz in Hyx.
@@ -1034,7 +1030,7 @@ Lemma curry_imset2l_dep :
   [set f x y | x in D1, y in D2 x] = \bigcup_(x in D1) f x @: D2 x.
 Proof.
 apply/setP=> y; apply/imset2P/bigcupP => [[x1 x2 Dx1 Dx2 ->{y}] | [x1 Dx1]].
-  by exists x1; rewrite // mem_imset.
+  by exists x1; rewrite // imset_f.
 by case/imsetP=> x2 Dx2 ->{y}; exists x1 x2.
 Qed.
 End imset2.
@@ -1357,7 +1353,7 @@ case: ifP.
   case: ifP => Hys.
     by rewrite !inE eqxx.
   rewrite inE; apply/orP; right.
-  by rewrite -edom_codom mem_imset.
+  by rewrite -edom_codom imset_f.
 Qed.
 
 Lemma step_edges_inj : {in step_edom &, injective step_edges}.
@@ -1372,12 +1368,12 @@ case: ifP => [/andP [Htriv Hcond]|Hcond] x y Hx Hy.
     move=> Hey.
     have Hy': y \in edom c by apply step_edom_edom.
     move/andP: Hcond => [_].
-    by rewrite /step_end_cond in_setD -edom_codom Hey mem_imset.
+    by rewrite /step_end_cond in_setD -edom_codom Hey imset_f.
   case: ifPn => Hys.
     move=> Hex.
     have Hx': x \in edom c by apply step_edom_edom.
     move/andP: Hcond => [_].
-    by rewrite /step_end_cond in_setD -edom_codom -Hex mem_imset.
+    by rewrite /step_end_cond in_setD -edom_codom -Hex imset_f.
   by move=> Heq; apply (@edges_inj _ c x y); auto using step_edom_edom.
 rewrite /step_edom /step_nodes Hcond in Hx Hy.
 by move=> Heq; apply (@edges_inj _ c x y).
@@ -1422,7 +1418,7 @@ Proof.
 move=> x Hx.
 rewrite /switch_edges ffunE.
 rewrite /switch_edom -(edom_codom c).
-rewrite mem_imset //.
+rewrite imset_f //.
 case: pickP.
   move=> y /andP [/eqP Hyx Hyc].
   by rewrite (edges_inj Hyc Hx Hyx).
@@ -1437,7 +1433,7 @@ rewrite /switch_edom -edom_codom.
 apply/imsetP.
 case: ifP => Hx.
 - exists (edges c x).
-    by rewrite mem_imset.
+    by rewrite imset_f.
   by rewrite switch_edges_cancel.
 - move => [y Hy Hxy].
   move/imsetP: Hy => [x' Hx' Hyx'].
@@ -1468,9 +1464,9 @@ Definition switch :=
 Lemma switch_edges_cancel2 : {in switch_edom, cancel switch_edges (edges c)}.
 Proof.
 move=> x Hx.
-have Hxc: switch_edges x \in edom c by rewrite -switch_edom_codom mem_imset.
+have Hxc: switch_edges x \in edom c by rewrite -switch_edom_codom imset_f.
 apply switch_edges_inj => //.
-  by rewrite /switch_edom -edom_codom mem_imset //.
+  by rewrite /switch_edom -edom_codom imset_f.
 by rewrite switch_edges_cancel.
 Qed.
 
@@ -1524,7 +1520,7 @@ case: x y => [[x|x][|]] [[y|y][|]] //=.
   move: (Hdom).
   rewrite inE => /andP [_] ->.
   move/setP/(_ y): (edom_codom c).
-  rewrite -(eqP Hed) mem_imset // inE.
+  rewrite -(eqP Hed) imset_f // inE.
   by move/esym/andP => [_] ->.
 - move/existsP => [s] /and4P[Hsg Hos Ho0s Hoo0].
   by split; split => //; apply/bigcupP; exists s.
@@ -1532,7 +1528,7 @@ case: x y => [[x|x][|]] [[y|y][|]] //=.
   move: (Hdom).
   rewrite inE => /andP [_] ->.
   move/setP/(_ x): (edom_codom c).
-  rewrite -(eqP Hed) mem_imset // inE.
+  rewrite -(eqP Hed) imset_f // inE.
   by move/esym/andP => [_] ->.
 - move/existsP => [s] /and4P[Hsg Hos Ho0s Hoo0].
   by split; split => //; apply/bigcupP; exists s.
@@ -1635,7 +1631,7 @@ case: ifP => Hp.
     by rewrite -Hx.
   move/(_ (edges c p)).
   rewrite switch_edges_cancel // eqxx /=.
-  by rewrite /edom -edom_codom mem_imset.
+  by rewrite /edom -edom_codom imset_f.
 by rewrite edges_out // inE Hp.
 Qed.
 
@@ -1668,14 +1664,14 @@ Proof.
 case Hx: (x \in _) => /=.
   case Hxy: (edges c x == y).
     rewrite -(eqP Hxy) switch_edges_cancel // eqxx andbT.
-    by rewrite -edom_codom mem_imset.
+    by rewrite -edom_codom imset_f.
   case Hy: (y \in _) => //=.
   case Hyx: (_ == _) => //.
   by rewrite -(eqP Hyx) switch_edges_cancel2 // eqxx in Hxy.
 case Hy: (y \in _) => //=.
 case Hyx: (_ == _) => //.
 rewrite -switch_edom_codom -(eqP Hyx) in Hx.
-by rewrite mem_imset in Hx.
+by rewrite imset_f in Hx.
 Qed.
 
 Lemma switch_graph_rel x y :
@@ -1797,7 +1793,7 @@ case: imsetP.
   by rewrite (inr_inj Hyy') Hy'.
 case Hyen: (y \in en) => //.
 move/imsetP.
-by rewrite mem_imset.
+by rewrite imset_f.
 Qed.
 
 Section connected_step_out.
@@ -2279,7 +2275,7 @@ case Hij: (j == i) => /=.
     rewrite prednK // lt0n.
     by move/eqP: Hk.
   case His: (_ && _ && _).
-    by rewrite mem_imset // inE andbC.
+    by rewrite imset_f // inE andbC.
   apply/imsetP => [] [s' Hs' [Hss']].
   by rewrite -Hss' !inE -topredE /= andbC His in Hs'.
 rewrite andbF.
@@ -2412,7 +2408,7 @@ have Hb2: b2 = true.
   case Hedge: (edges c b == _) => //=.
   move/andP: Hsc => [Hsp].
   rewrite /step_end_cond inE.
-  move/(mem_imset (edges c)): Hbdom.
+  move/(imset_f (edges c)): Hbdom.
   by rewrite edom_codom (eqP Hedge) => ->.
 subst b2.
 have Hlen: (size p' < #|port|*4)%nat.
@@ -2553,7 +2549,7 @@ have Hix': x' = i.1.
     by rewrite eq_sym => /eqP.
   move: (step_edom_edom Htriv Hsc (negbT Hx''p) Hex'') => Hx''e Hed.
   move/setP/(_ x'): (edom_codom c).
-  rewrite -{1}(eqP Hed) mem_imset //= => /esym.
+  rewrite -{1}(eqP Hed) imset_f //= => /esym.
   rewrite !inE => /andP [_] Hx'p.
   elim (negP Hxkp).
   apply/bigcupP; exists i.2 => //.
@@ -2569,7 +2565,7 @@ have Hix: x = i.1.
     by rewrite eq_sym => /eqP.
   move: (step_edom_edom Htriv Hsc (negbT Hx''p) Hex'') => Hx''e Hed.
   move/setP/(_ x): (edom_codom c).
-  rewrite -{1}(eqP Hed) mem_imset //= => /esym.
+  rewrite -{1}(eqP Hed) imset_f //= => /esym.
   rewrite !inE => /andP [_] Hx'p.
   elim (negP Hxkp).
   apply/bigcupP; exists i.2 => //.

--- a/ecc_modern/ldpc_algo_proof.v
+++ b/ecc_modern/ldpc_algo_proof.v
@@ -1459,7 +1459,7 @@ transitivity
   destruct k; by rewrite (eq_filter Hp) filter_pred0 // cats0.
 congr (map _ _).
 apply eq_filter => x /=; rewrite !inE.
-case Hx: (x \in s); first by rewrite mem_imset.
+case/boolP : (x \in s) => /= Hx; first by rewrite imset_f.
 case /boolP: (inj x \in _) => // /imsetP [y Hy] /id_of_kind_inj xy.
 by rewrite xy Hy in Hx.
 Qed.
@@ -2166,9 +2166,8 @@ split.
 move=> n0.
 have Hn0 := get_esti_ok n0.
 set estimations := estimation _ in Hn0 *.
-have Hsq := get_esti_subseq n0 estimations.
-rewrite Hn0 /= in Hsq.
-by rewrite -sub1seq.
+have := get_esti_subseq n0 estimations.
+by rewrite Hn0 /= -sub1seq.
 Qed.
 
 End AlgoProof.

--- a/ecc_modern/subgraph_partition.v
+++ b/ecc_modern/subgraph_partition.v
@@ -284,7 +284,7 @@ case/connectP : nv => t' /shortenP[t nt uniq_nt _] ->{v t'}.
 case: t => [|h t] in nt uniq_nt *.
   by exists [set n]; rewrite !inE // eqxx.
 exists (subgraph g h n).
-  rewrite inE /subgraph_succ (mem_imset ((subgraph g)^~ n)) ?orbT //.
+  rewrite inE /subgraph_succ (imset_f ((subgraph g)^~ n)) ?orbT //.
   rewrite inE; rewrite /= in nt; by case/andP : nt.
 rewrite inE /=.
 rewrite /= in nt.
@@ -403,7 +403,7 @@ case => [_ /= _ _ ? | h t' /=].
   by subst v; rewrite eqxx in vm.
 case/andP; rewrite {1}exceptE /= => /and3P[mh mn hn] H4 Hun t't vt.
 exists (subgraph g h m).
-  by rewrite (mem_imset (subgraph g ^~ m)) // !inE hn.
+  by rewrite (imset_f (subgraph g ^~ m)) // !inE hn.
 rewrite /subgraph inE mh /=.
 apply/connectP; exists t' => //.
 case/andP : Hun; rewrite inE negb_or => /andP[m_neq_h mt'] _.

--- a/ecc_modern/summary.v
+++ b/ecc_modern/summary.v
@@ -346,7 +346,7 @@ case: ifP => [Hi|Hi].
   move/subsetP: Hj; apply => k Hk.
   move: (Hjs _ Hk).
   rewrite !inE => /orP[/eqP ?|//].
-  subst n1; by rewrite Hk in Hn1j.
+  by subst n1; rewrite Hk in Hn1j.
 Qed.
 
 End alternative_definitions_of_summary.

--- a/information_theory/jtypes.v
+++ b/information_theory/jtypes.v
@@ -1010,12 +1010,12 @@ case: (tuple_exist_perm_sort (@le_rank A) ta) => s /=.
 rewrite /sort_tuple /=.
 set t' := Tuple _.
 move=> ta_t'.
-have t'ta : t' = perm_tuple s^-1 ta by rewrite ta_t' perm_tuple_comp mulVg perm_tuple_id.
+have t'ta : t' = perm_tuple s^-1 ta.
+  by rewrite ta_t' perm_tuple_comp mulVg perm_tuple_id.
 have sorted_t' : sorted (@le_rank A) t' by exact/sort_sorted/le_rank_total.
 have Ht' : t' \in T_{P} by rewrite t'ta; apply/perm_tuple_in_Ttuples.
 case: (shell_not_empty_sorted sorted_t' Hrow_num_occ Ht') => tb Htb.
-exists (perm_tuple s tb).
-rewrite ta_t' perm_Stuples_Stuples_perm; by apply mem_imset.
+by exists (perm_tuple s tb); rewrite ta_t' perm_Stuples_Stuples_perm imset_f.
 Qed.
 
 End shell_not_empty.

--- a/information_theory/kraft.v
+++ b/information_theory/kraft.v
@@ -41,7 +41,7 @@ Lemma sorted_leq_last s : sorted leq s -> forall i, i \in s -> i <= last 0 s.
 Proof.
 move=> H /= i; case/(nthP O) => {}i Hi <-; rewrite -nth_last.
 case/boolP : (i == (size s).-1) => [/eqP <- //|si].
-apply (sorted_lt_nth leq_trans) => //.
+apply (sorted_ltn_nth leq_trans) => //.
 by rewrite inE prednK // (leq_trans _ Hi).
 by rewrite ltn_neqAle si /= -ltnS prednK // (leq_trans _ Hi).
 Qed.
@@ -429,9 +429,9 @@ rewrite /w (bigID (fun i1 : 'I__ => i1 < i)) /=.
 set a := (X in X + _ = _ -> _). set b := (X in _ = X -> _).
 set c := (X in _ + X = _ -> _).
 have ab : a >= b.
-  rewrite {}/a {}/b big_ord_narrow; [by apply ltnW|move=> H].
+  rewrite {}/a {}/b big_ord_narrow; [exact: ltnW|move=> H].
   apply: leq_sum => k _; rewrite leq_exp2l ?card_ord // leq_sub //.
-  apply/(sorted_lt_nth leq_trans) => //; by rewrite inE l_n.
+  by apply/(sorted_ltn_nth leq_trans) => //; rewrite inE l_n.
 have c0 : 0 < c.
   rewrite {}/c lt0n sum_nat_eq0 negb_forall.
   apply/existsP; exists (Ordinal ij); by rewrite /= ltnn /= expn_eq0 card_ord.
@@ -627,7 +627,7 @@ rewrite mulrBr mulVr ?unitfE ?mulr1 ?pnatr_eq0 ?expn_eq0 //.
 rewrite /w // natr_sum big_distrr /=.
 rewrite (eq_bigr (fun j : 'I__ => #|T|%:R ^-nth O l j))%R; last first.
   move=> i _; rewrite !natrX card_ord exprB; last 2 first.
-    apply/(sorted_lt_nth leq_trans) => //; rewrite inE l_n //.
+    apply/(sorted_ltn_nth leq_trans) => //; rewrite inE l_n //.
     by rewrite (leq_trans (ltn_ord i)) // ltnW.
     by rewrite unitfE pnatr_eq0.
   by rewrite mulrA mulVr ?unitfE -?natrX ?pnatr_eq0 ?expn_eq0 // mul1r.
@@ -664,7 +664,7 @@ rewrite ltn_neqAle; apply/andP; split.
 rewrite size_sigma //; last by rewrite -/t -(card_ord t) w_sub.
 rewrite size_sigma //; last by rewrite -/t -(card_ord t) w_sub.
 move: ba; rewrite leq_eqVlt => /orP[/eqP ->//|ba].
-by apply/(sorted_lt_nth leq_trans) => //; rewrite inE l_n.
+by apply/(sorted_ltn_nth leq_trans) => //; rewrite inE l_n.
 Qed.
 
 End kraft_code.
@@ -705,11 +705,11 @@ have H1 : (r >= (w j)%:R + (1 : R))%R. (*\color{comment}{\framebox{here we prove
       by rewrite unitfE expf_eq0 card_ord pnatr_eq0 andbF.
     apply: (@mulIr _ (#|T|%:R ^+ (l``_k - l``_j))%R) => //.
     rewrite natrX -mulrA mulVr // mulr1 exprB; last 2 first.
-      apply/(sorted_lt_nth leq_trans) => //; rewrite inE l_n //.
+      apply/(sorted_ltn_nth leq_trans) => //; rewrite inE l_n //.
       by rewrite (leq_trans (ltn_ord i)) // ltnW.
       by rewrite unitfE pnatr_eq0 card_ord.
     rewrite exprB; last 2 first.
-      by apply/(sorted_lt_nth leq_trans) => //; rewrite inE l_n.
+      by apply/(sorted_ltn_nth leq_trans) => //; rewrite inE l_n.
       by rewrite unitfE pnatr_eq0 card_ord.
     rewrite mulrCA mulrAC mulrV // ?mul1r //.
     by rewrite unitfE -natrX pnatr_eq0 expn_eq0 card_ord.
@@ -723,7 +723,7 @@ have H1 : (r >= (w j)%:R + (1 : R))%R. (*\color{comment}{\framebox{here we prove
     rewrite /r' /u -(big_mkord xpredT f)%R natr_sum.
     rewrite (eq_bigr (fun i : 'I__ => f i)); last first.
       move=> i _; rewrite natrX exprB //.
-      apply/(sorted_lt_nth leq_trans) => //; rewrite inE l_n //.
+      apply/(sorted_ltn_nth leq_trans) => //; rewrite inE l_n //.
       by rewrite (leq_trans (ltn_ord i)) // ltnW.
       by rewrite unitfE pnatr_eq0 card_ord.
     by rewrite -(big_mkord xpredT f)%R -big_cat_nat //= ltnW.

--- a/information_theory/source_coding_fl_converse.v
+++ b/information_theory/source_coding_fl_converse.v
@@ -91,24 +91,21 @@ Proof.
 apply (@leR_trans (exp2 n%:R)).
   rewrite /no_failure.
   have Hsubset : [set x | dec sc (enc sc x) == x] \subset dec sc @: (enc sc @: [set: 'rV[A]_k.+1]).
-    apply/subsetP => x.
-    rewrite inE => Hx.
-    apply/imsetP.
-    exists (enc sc x).
-    - apply mem_imset; by rewrite inE.
-    - by move/eqP in Hx.
+    apply/subsetP => x; rewrite inE => /eqP Hx.
+    by apply/imsetP; exists (enc sc x) => //; rewrite imset_f.
   apply (@leR_trans #| dec sc @: (enc sc @: [set: 'rV[A]_k.+1]) |%:R).
     by apply/le_INR/leP; case/subset_leqif_cards : Hsubset.
   apply (@leR_trans #| dec sc @: [set: 'rV[bool]_n] |%:R).
-    apply/le_INR/leP/subset_leqif_cards/imsetS/subsetP => x Hx; by rewrite inE.
+    by apply/le_INR/leP/subset_leqif_cards/imsetS/subsetP => x Hx; rewrite inE.
   apply (@leR_trans #| [set: 'rV[bool]_n] |%:R).
-    apply/le_INR/leP/leq_imset_card.
-    rewrite cardsT card_matrix /= card_bool natRexp2 mul1n; exact/leRR.
+    exact/le_INR/leP/leq_imset_card.
+  by rewrite cardsT card_matrix /= card_bool natRexp2 mul1n; exact/leRR.
 apply Exp_le_increasing => //.
 rewrite /e0 [X in _ <= _ * X](_ : _ = r); last by field.
 apply (@leR_pmul2r (1 / r)) => //.
-apply divR_gt0; [lra | tauto].
-rewrite -mulRA div1R mulRV ?mulR1; last by case: Hr => /ltRP; rewrite lt0R => /andP[].
+  by apply divR_gt0; [lra | tauto].
+rewrite -mulRA div1R mulRV ?mulR1; last first.
+  by case: Hr => /ltRP; rewrite lt0R => /andP[].
 by case/leR_max : Hk.
 Qed.
 

--- a/lib/euclid.v
+++ b/lib/euclid.v
@@ -824,9 +824,9 @@ Lemma solve_key_equation_coprimep p t :
   exists k, k <> 0 /\ v stop = k *: V /\ r stop = k *: R.
 Proof.
 move=> H1 Hmu Hnu H2 Hco j.
-case: (solve_key_equation H1 Hmu Hnu H2) => l [l_neq0 [vvi rrj]].
+have [l [l_neq0 [vvi rrj]]] := solve_key_equation H1 Hmu Hnu H2.
 move: Hco.
-rewrite {1}vvi {1}rrj coprimep_mulr coprimep_mull coprimepp => /andP[/andP[]].
+rewrite {1}vvi {1}rrj coprimepMr coprimepMl coprimepp => /andP[/andP[]].
 case/size_poly1P => k k_neq0 lk _ _.
 exists k^-1; split; first by apply/eqP; rewrite invr_eq0.
 split.

--- a/lib/poly_ext.v
+++ b/lib/poly_ext.v
@@ -95,5 +95,6 @@ Proof. by move=> /eqP ->; apply/eqP/rowP => i; rewrite !mxE coef0. Qed.
 
 End AboutPoly.
 
-Lemma morph_modp (F : fieldType) (p : {poly F}) : {morph (fun x : {poly F} => x %% p) : x y / x + y}.
-Proof. move=> x y; by rewrite modp_add. Qed.
+Lemma morph_modp (F : fieldType) (p : {poly F}) :
+  {morph (fun x : {poly F} => x %% p) : x y / x + y}.
+Proof. move=> x y; by rewrite modpD. Qed.

--- a/lib/ssr_ext.v
+++ b/lib/ssr_ext.v
@@ -296,10 +296,10 @@ elim=> [[]// k _ _ _ Hk H|] /=.
   by rewrite !inE eqxx orTb in_nil => /(_ isT).
 move=> n0 IH [|hd tl] // v [lst_sz] lst_uniq lst_sorted v_sorted Hincl.
 have X1 : v = filter (pred1 hd) v ++ filter (predC (pred1 hd)) v.
-  apply eq_sorted with leT => //.
+  apply: (@sorted_eq _ leT) => //.
   - apply: sorted_cat.
-    + by apply sorted_filter.
-    + by apply sorted_filter.
+    + exact: sorted_filter.
+    + exact: sorted_filter.
     + move=> a.
       rewrite mem_filter => /andP[/= /eqP ?]; subst hd => av b.
       rewrite mem_filter => /andP[/= ba /Hincl].
@@ -307,10 +307,10 @@ have X1 : v = filter (pred1 hd) v ++ filter (predC (pred1 hd)) v.
       * move/eqP => ?; by subst b.
       * move=> btl.
         rewrite /sorted in lst_sorted.
-        move: (@subseq_order_path _ _ (Htrans) a [:: b] tl).
-        rewrite /= andbC /=.
-        apply => //; by rewrite sub1seq.
-  - rewrite perm_sym; by apply permEl, perm_filterC.
+        have /= := @subseq_path _ _ Htrans a [:: b] tl.
+        rewrite andbT.
+        by apply => //; rewrite sub1seq.
+  - by rewrite perm_sym; apply permEl, perm_filterC.
 rewrite {1}X1 {X1} /=.
 congr (_ ++ _).
 move: lst_uniq => /= /andP[hdtl tl_uniq].
@@ -328,7 +328,7 @@ rewrite (IH tl (filter (predC (pred1 hd)) v) lst_sz tl_uniq).
 - exact: sorted_filter.
 - move=> i.
   rewrite mem_filter /= => /andP[ihd] /Hincl.
-  rewrite inE => /orP[|//]; by rewrite (negbTE ihd).
+  by rewrite inE => /orP[|//]; rewrite (negbTE ihd).
 Qed.
 
 Lemma filter_zip_L m (l : seq A) (k : seq B) a :
@@ -570,7 +570,7 @@ Definition fin_img (A : finType) (B : eqType) (f : A -> B) : seq B := undup (map
 Lemma fin_img_imset (A B : finType) (f : A -> B) : fin_img f =i f @: A.
 Proof.
 apply/subset_eqP/andP; split; apply/subsetP => b; rewrite mem_undup; case/boolP : [exists a, b  == f a].
-- by case/existsP => a /eqP ->; rewrite mem_imset.
+- by case/existsP => a /eqP ->; rewrite imset_f.
 - rewrite negb_exists; move/forallP=> bfx.
   case/mapP => a _ bfa.
     by move: (bfx a); rewrite bfa => /eqP.

--- a/meta.yml
+++ b/meta.yml
@@ -43,40 +43,40 @@ supported_coq_versions:
   opam: '{ (>= "8.11" & < "8.13~") | (= "dev") }'
 
 tested_coq_opam_versions:
-- version: '1.11.0-coq-8.11'
+- version: '1.12.0-coq-8.11'
   repo: 'mathcomp/mathcomp'
-- version: '1.11.0-coq-8.12'
+- version: '1.12.0-coq-8.12'
   repo: 'mathcomp/mathcomp'
 
 dependencies:
 - opam:
     name: coq-mathcomp-ssreflect
-    version: '{ (>= "1.11.0" & < "1.12~") }'
+    version: '{ (>= "1.12.0" & < "1.13~") }'
   description: |-
-    [MathComp ssreflect 1.11](https://math-comp.github.io)
+    [MathComp ssreflect 1.12](https://math-comp.github.io)
 - opam:
     name: coq-mathcomp-fingroup
-    version: '{ (>= "1.11.0" & < "1.12~") }'
+    version: '{ (>= "1.12.0" & < "1.13~") }'
   description: |-
-    [MathComp fingroup 1.11](https://math-comp.github.io)
+    [MathComp fingroup 1.12](https://math-comp.github.io)
 - opam:
     name: coq-mathcomp-algebra
-    version: '{ (>= "1.11.0" & < "1.12~") }'
+    version: '{ (>= "1.12.0" & < "1.13~") }'
   description: |-
-    [MathComp algebra 1.11](https://math-comp.github.io)
+    [MathComp algebra 1.12](https://math-comp.github.io)
 - opam:
     name: coq-mathcomp-solvable
-    version: '{ (>= "1.11.0" & < "1.12~") }'
+    version: '{ (>= "1.12.0" & < "1.13~") }'
   description: |-
-    [MathComp solvable 1.11](https://math-comp.github.io)
+    [MathComp solvable 1.12](https://math-comp.github.io)
 - opam:
     name: coq-mathcomp-field
-    version: '{ (>= "1.11.0" & < "1.12~") }'
+    version: '{ (>= "1.12.0" & < "1.13~") }'
   description: |-
-    [MathComp field 1.11](https://math-comp.github.io)
+    [MathComp field 1.12](https://math-comp.github.io)
 - opam:
     name: coq-mathcomp-analysis
-    version: '{ (= "0.3.4") }'
+    version: '{ (>= "0.3.4") }'
   description: |-
     [MathComp analysis 0.3.4](https://github.com/math-comp/analysis)
 namespace: infotheo


### PR DESCRIPTION
TODO: get rid of the `big_enumP` warnings as well (they will become error with the next release)

@garrigue @t6s 