### PR TITLE
Conv set

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,41 @@
+-------------------
+from 0.3.1 to 0.3.?
+-------------------
+
+* added:
+
+- in Reals_ext.v:
+  + lemmas onem_le, onem_lt
+  + module OProb for inferring values in the open unit interval
+    * notation %:opr
+    * technical lemmas oprob_gt0, oprobK, oprob_pdivRnnm, oprob_add_gt0, etc.
+    * a canonical instance for the cplt and the multiplication of two oprob's
+  + a canonical instance of Rpos for oprob
+  + lemmas onem_prob, onem_oprob
+  + lemmas prob_trichotomy and prob_trichotomy'
+- in ssrR.v:
+  + lemma ltR_subr_addr
+- in convex.v:
+  + lemmas convA'_oprob, convACA'
+- in fdist.v:
+  + technical lemmas about oprob and s_of, r_of, p_of, q_of
+    * with canonical instances
+- in necset.v:
+  + lemmas conv_in_conv_pt_set, conv_in_conv_set, convA_pt_set, etc.
+  + lemma affine_image_conv_set
+  + lemma conv_pt_cset_is_convex, canonical conv_pt_cset,
+    lemma conv_pt_cset, canonical conv_cset,
+    lemma oplus_conv_cset_is_convex, canonical oplus_conv_cset
+
+* changed:
+  + modify the convex space structure on (convex_set _) to reuse conv_set instead of
+    differently defining another convex combination operation
+  + move and rename convex.{Rpos_prob_Op1, Rpos_prob, Rpos_probC}
+    to Reals_ext.{prob_divRposxxy, divRposxxy, divRposxxyC}.
+
+* moved:
+  + lemma onem_div from convex.v to Reals_ext.v
+
 -----------------
 from 0.3 to 0.3.1
 -----------------

--- a/lib/Reals_ext.v
+++ b/lib/Reals_ext.v
@@ -507,6 +507,24 @@ Qed.
 Lemma prob_lt1' p : p != 1 :> R <-> (p < 1)%R.
 Proof. exact: prob_lt1. Qed.
 
+Lemma prob_trichotomy (p : prob) : p = 0%:pr  \/ p = 1%:pr \/ 0 < p < 1.
+Proof.
+case/boolP: (p == 0%:pr); first by move/eqP ->; left.
+move=> pneq0; right.
+case/boolP: (p == 1%:pr); first by move/eqP ->; left.
+by move=> pneq1; right; split; [apply prob_gt0 | apply prob_lt1].
+Qed.
+
+Lemma prob_trichotomy' (p : prob) (P : prob -> Prop) :
+  P 0%:pr -> P 1%:pr -> (forall o : oprob, P o) -> P p.
+Proof.
+move=> p0 p1 po.
+case: (prob_trichotomy p); first by move->.
+case; first by move->.
+move/oprob_oprobb=> H.
+exact: (po (OProb.mk H)).
+Qed.
+
 End prob_lemmas.
 
 Lemma probK t : t = (t.~).~%:pr :> prob.

--- a/lib/Reals_ext.v
+++ b/lib/Reals_ext.v
@@ -359,20 +359,14 @@ Qed.
 
 Lemma onem_prob r : (0%R <b= r <b= R1)%R -> (0%R <b= r.~ <b= R1)%R.
 Proof.
-case/andP=> /leRP rO /leRP r1; apply/andP; split; apply/leRP;
-              by [rewrite leR_subr_addr add0R | rewrite leR_subl_addr -(addR0 1) leR_add2l].
+by case/leR2P=> ? ?; apply/leR2P; split;
+   [rewrite leR_subr_addr add0R | rewrite leR_subl_addr -(addR0 1) leR_add2l].
 Qed.
 
-Lemma onem_oprob r : (0%R < r < R1)%R -> (0%R < r.~ < R1)%R.
+Lemma onem_oprob r : (0%R <b r <b R1)%R -> (0%R <b r.~ <b R1)%R.
 Proof.
-by case=> rO r1; split;
-            by [rewrite ltR_subr_addr add0R | rewrite ltR_subl_addr -(addR0 1) ltR_add2l].
-Qed.
-
-Lemma onem_oprobb r : (0%R <b r <b R1)%R -> (0%R <b r.~ <b R1)%R.
-Proof.
-case/andP=> /ltRP rO /ltRP r1; apply/andP; split; apply/ltRP;
-              by [rewrite ltR_subr_addr add0R | rewrite ltR_subl_addr -(addR0 1) ltR_add2l].
+by case/ltR2P=> ? ?; apply/ltR2P; split;
+   [rewrite ltR_subr_addr add0R | rewrite ltR_subl_addr -(addR0 1) ltR_add2l].
 Qed.
 
 Lemma onem_eq0 r : r.~ = 0 <-> r = 1. Proof. rewrite /onem; lra. Qed.
@@ -397,7 +391,6 @@ Record t := mk {
   p :> R ;
   Op1 : (0 <b= p <b= 1)%R }.
 Definition O1 (p : t) : 0 <b= p <b= 1 := Op1 p.
-(*Definition O1P (p : t) : 0 <= p <= 1 := elimT (@leR2P _ _ _) (O1 p).*)
 Arguments O1 : simpl never.
 Definition mk_ (q : R) (Oq1 : 0 <= q <= 1) := mk (introT (@leR2P _ _ _) Oq1).
 Module Exports.
@@ -411,14 +404,6 @@ End Prob.
 Export Prob.Exports.
 Coercion Prob.p : prob >-> R.
 
-Lemma oprob_prob r : 0 < r < 1 -> 0 <= r <= 1.
-Proof. by case=> /ltRW ? /ltRW ?; split. Qed.
-
-Lemma oprob_oprobb x  : 0 < x < 1 -> 0 <b x <b 1.
-Proof. by case=> *; apply/andP; split; apply/ltRP. Qed.
-Lemma oprobb_oprob x  : 0 <b x <b 1 -> 0 < x < 1.
-Proof. by case/andP=> /ltRP ? /ltRP ?; split. Qed.
-
 Module OProb.
 Section def.
 Record t := mk {
@@ -426,20 +411,6 @@ Record t := mk {
   Op1 : (0 <b p <b 1)%R }.
 Definition O1 (p : t) : 0 <b p <b 1 := Op1 p.
 Arguments O1 : simpl never.
-(*
-Lemma oprob_probMixin (p : R) : 0 < p < 1 -> 0 <b= p <b= 1.
-Proof. by case => /ltRP /ltRW' -> /ltRP /ltRW' ->. Qed.
-Definition mk_ (q : R) (Oq1 : 0 < q < 1) : t.
-Proof.
-refine (@mk (Prob.mk (oprob_probMixin Oq1))%:pr (match Oq1 with conj Oq q1 => _ end)).
-simpl.
-by move/ltRP: Oq ->; move/ltRP: q1 ->.
-Defined.
-*)
-(*
-Lemma oprob_probMixin (p : t) : 0 <b= p <b= 1.
-Proof. by case/andP: (Op1 p) => /ltRW' -> /ltRW' ->. Qed.
-*)
 End def.
 Module Exports.
 Notation oprob := t.
@@ -454,14 +425,14 @@ Coercion OProb.p : oprob >-> prob.
 
 Lemma probpK p H : Prob.p (@Prob.mk p H) = p. Proof. by []. Qed.
 
-Lemma OO1 : (R0 <= R0 <= R1)%R. Proof. lra. Qed.
+Lemma OO1 : (R0 <b= R0 <b= R1)%R. Proof. apply/leR2P; lra. Qed.
 
-Lemma O11 : (R0 <= R1 <= R1)%R. Proof. lra. Qed.
+Lemma O11 : (R0 <b= R1 <b= R1)%R. Proof. apply/leR2P; lra. Qed.
 
-Canonical prob0 := Eval hnf in Prob.mk_ OO1.
-Canonical prob1 := Eval hnf in Prob.mk_ O11.
-Canonical probcplt (p : prob) := Eval hnf in Prob.mk (onem_probb (Prob.O1 p)).
-Canonical oprobcplt (p : oprob) := Eval hnf in OProb.mk (onem_oprobb (OProb.O1 p)).
+Canonical prob0 := Eval hnf in Prob.mk OO1.
+Canonical prob1 := Eval hnf in Prob.mk O11.
+Canonical probcplt (p : prob) := Eval hnf in Prob.mk (onem_prob (Prob.O1 p)).
+Canonical oprobcplt (p : oprob) := Eval hnf in OProb.mk (onem_oprob (OProb.O1 p)).
 
 Lemma prob_ge0 (p : prob) : 0 <= p%R.
 Proof. by case: p => p /= /leR2P[]. Qed.
@@ -521,7 +492,7 @@ Proof.
 move=> p0 p1 po.
 case: (prob_trichotomy p); first by move->.
 case; first by move->.
-move/oprob_oprobb=> H.
+move/ltR2P=> H.
 exact: (po (OProb.mk H)).
 Qed.
 
@@ -531,34 +502,34 @@ Lemma probK t : t = (t.~).~%:pr :> prob.
 Proof. by apply val_inj => /=; rewrite onemK. Qed.
 
 Lemma oprobK t : t = (t.~).~%:opr :> oprob.
-Proof. by apply val_inj => /=; rewrite onemK. Qed.
+Proof. by apply/val_inj/val_inj=> /=; rewrite onemK. Qed.
 
-Lemma prob_IZR (p : positive) : (R0 <= / IZR (Zpos p) <= R1)%R.
+Lemma prob_IZR (p : positive) : (R0 <b= / IZR (Zpos p) <b= R1)%R.
 Proof.
-split; first exact/Rlt_le/Rinv_0_lt_compat/IZR_lt/Pos2Z.is_pos.
+apply/leR2P; split; first exact/Rlt_le/Rinv_0_lt_compat/IZR_lt/Pos2Z.is_pos.
 rewrite -[X in (_ <= X)%R]Rinv_1; apply Rle_Rinv => //.
 - exact/IZR_lt/Pos2Z.is_pos.
 - exact/IZR_le/Pos2Z.pos_le_pos/Pos.le_1_l.
 Qed.
 
-Canonical probIZR (p : positive) := Eval hnf in @Prob.mk_ _ (prob_IZR p).
+Canonical probIZR (p : positive) := Eval hnf in Prob.mk (prob_IZR p).
 
 Definition divRnnm n m := INR n / INR (n + m).
 
-Lemma prob_divRnnm n m : (0 <= divRnnm n m <= 1)%R.
+Lemma prob_divRnnm n m : (0 <b= divRnnm n m <b= 1)%R.
 Proof.
-rewrite /divRnnm.
-have [/eqP ->|n0] := boolP (n == O); first by rewrite div0R; exact OO1.
+apply/leR2P; rewrite /divRnnm.
+have [/eqP ->|n0] := boolP (n == O); first by rewrite div0R; apply/leR2P/OO1.
 split; first by apply divR_ge0; [exact: leR0n | rewrite ltR0n addn_gt0 lt0n n0].
 by rewrite leR_pdivr_mulr ?mul1R ?leR_nat ?leq_addr // ltR0n addn_gt0 lt0n n0.
 Qed.
 
 Canonical probdivRnnm (n m : nat) :=
-  Eval hnf in @Prob.mk_ (divRnnm n m) (prob_divRnnm n m).
+  Eval hnf in @Prob.mk (divRnnm n m) (prob_divRnnm n m).
 
-Lemma prob_invn (m : nat) : (R0 <= / (1 + m)%:R <= R1)%R.
+Lemma prob_invn (m : nat) : (R0 <b= / (1 + m)%:R <b= R1)%R.
 Proof.
-rewrite -(mul1R (/ _)%R) (_ : 1%R = INR 1) // -/(Rdiv _ _); exact: prob_divRnnm.
+apply/leR2P; rewrite -(mul1R (/ _)%R) (_ : 1%R = INR 1) // -/(Rdiv _ _); apply/leR2P; exact: prob_divRnnm.
 Qed.
 
 Lemma oprob_pdivRnnm n m : (0 < n)%nat -> (0 < m)%nat -> (0 < divRnnm n m < 1)%R.
@@ -566,36 +537,35 @@ Proof.
 rewrite /divRnnm.
 split; first by apply divR_gt0; [rewrite ltR0n | rewrite ltR0n addn_gt0 H orTb].
 rewrite ltR_pdivr_mulr ?mul1R ?ltR_nat // ?ltR0n ?addn_gt0 ?H ?orTb //.
-by rewrite -{1}(addn0 n) ltn_add2l.
+by rewrite -[X in (X < _)%nat](addn0 n) ltn_add2l.
 Qed.
 
-(* was Canonical *)
-Definition probinvn (n : nat) :=
-  Eval hnf in @Prob.mk_ (/ INR (1 + n)) (prob_invn n).
+Canonical probinvn (n : nat) :=
+  Eval hnf in @Prob.mk (/ INR (1 + n)) (prob_invn n).
 
-Lemma prob_invp (p : prob) : (0 <= 1 / (1 + p) <= 1)%R.
+Lemma prob_invp (p : prob) : (0 <b= 1 / (1 + p) <b= 1)%R.
 Proof.
-split.
+apply/leR2P; split.
 - by apply divR_ge0 => //; exact: addR_gt0wl.
 - rewrite leR_pdivr_mulr ?mul1R; last exact: addR_gt0wl.
   by rewrite addRC -leR_subl_addr subRR.
 Qed.
-Definition Prob_invp (p : prob) := Prob.mk_ (prob_invp p).
+Definition Prob_invp (p : prob) := Prob.mk (prob_invp p).
 
-Lemma prob_mulR (p q : prob) : (0 <= p * q <= 1)%R.
-Proof. by split; [exact/mulR_ge0 |rewrite -(mulR1 1%R); apply leR_pmul]. Qed.
+Lemma prob_mulR (p q : prob) : (0 <b= p * q <b= 1)%R.
+Proof. by apply/leR2P; split; [exact/mulR_ge0 |rewrite -(mulR1 1%R); apply leR_pmul]. Qed.
 
 Canonical probmulR (p q : prob) :=
-  Eval hnf in @Prob.mk_ (p * q) (prob_mulR p q).
+  Eval hnf in @Prob.mk (p * q) (prob_mulR p q).
 
-Lemma oprob_mulR (p q : oprob) : (0 < p * q < 1)%R.
+Lemma oprob_mulR (p q : oprob) : (0 <b p * q <b 1)%R.
 Proof.
-split; first by apply/mulR_gt0/oprob_gt0/oprob_gt0.
+apply/ltR2P; split; first by apply/mulR_gt0/oprob_gt0/oprob_gt0.
 by rewrite -(mulR1 1%R); apply ltR_pmul;
   [exact/oprob_ge0 | exact/oprob_ge0 | exact/oprob_lt1 | exact/oprob_lt1].
 Qed.
 Canonical oprobmulR (p q : oprob) :=
-  Eval hnf in @OProb.mk (p * q)%:pr (oprob_oprobb (oprob_mulR p q)).
+  Eval hnf in @OProb.mk (p * q)%:pr (oprob_mulR p q).
 
 Lemma probadd_eq0 (p q : prob) : p + q = 0%:pr <-> p = 0%:pr /\ q = 0%:pr.
 Proof.
@@ -721,36 +691,26 @@ Canonical mulRpos x y := Rpos.mk (mulRpos_gt0 x y).
 Lemma divRpos_gt0 (x y : Rpos) : x / y >b 0. Proof. exact/ltRP/divR_gt0. Qed.
 Canonical divRpos x y := Rpos.mk (divRpos_gt0 x y).
 
-Lemma Rpos_prob_Op1 (r q : Rpos) : 0 <= r / (r + q)%:pos <= 1.
+Canonical oprob_Rpos (p : oprob) := @mkRpos p (oprob_gt0 p).
+
+Lemma oprob_divRposxxy (x y : Rpos) : (0 <b (x / (x + y)) <b 1)%R.
 Proof.
-split; first exact/ltRW/divR_gt0.
-apply leR_pdivr_mulr => //.
-rewrite mul1R; exact/leR_addl/ltRW.
+apply/ltR2P; split; first by apply/divR_gt0.
+rewrite ltR_pdivr_mulr ?mul1R; last exact/ltRP/addRpos_gt0.
+by rewrite ltR_addl.
 Qed.
+Lemma prob_divRposxxy (x y : Rpos) : (0 <b= (x / (x + y)) <b= 1)%R.
+Proof. by apply/leR2P/ltR2W/ltR2P/oprob_divRposxxy. Qed.
+Canonical divRposxxy (x y : Rpos) :=
+  Eval hnf in Prob.mk (prob_divRposxxy x y).
+Canonical divRposxxy_oprob (x y : Rpos) :=
+  Eval hnf in OProb.mk (oprob_divRposxxy x y).
 
-Definition Rpos_prob (r q : Rpos) := Eval hnf in Prob.mk_ (Rpos_prob_Op1 r q).
-
-Lemma Rpos_probC r q : Rpos_prob q r = (Rpos_prob r q).~%:pr.
+Lemma divRposxxyC r q : divRposxxy q r = (divRposxxy r q).~%:pr.
 Proof.
 apply val_inj => /=; rewrite [in RHS]addRC onem_div ?addRK //.
 exact: Rpos_neq0.
 Qed.
-
-Canonical oprob_Rpos (p : oprob) := @mkRpos p (oprob_gt0 p).
-
-Lemma oprob_divRposxxy (x y : Rpos) : (0 < (x / (x + y)) < 1)%R.
-Proof.
-split; first by apply/divR_gt0.
-rewrite ltR_pdivr_mulr ?mul1R; last exact/ltRP/addRpos_gt0.
-by rewrite ltR_addl.
-Qed.
-Lemma prob_divRposxxy (x y : Rpos) : (0 <= (x / (x + y)) <= 1)%R.
-Proof. by apply/oprob_prob/oprob_divRposxxy. Qed.
-Canonical divRposxxt (x y : Rpos) :=
-  Eval hnf in @Prob.mk _ (prob_probb (prob_divRposxxy x y)).
-Canonical divRposxxt_oprob (x y : Rpos) :=
-  Eval hnf in @OProb.mk _ (oprob_oprobb (oprob_divRposxxy x y)).
-
 
 Module Rnneg.
 Local Open Scope R_scope.

--- a/lib/ssrR.v
+++ b/lib/ssrR.v
@@ -448,6 +448,9 @@ split => [/(@ltR_add2r y)|/(@ltR_add2r (- y))]; first by rewrite subRK addRC.
 by rewrite addR_opp (addRC y) addR_opp addRK.
 Qed.
 
+Lemma ltR_subr_addr x y z : (x < y - z) <-> (x + z < y).
+Proof. by rewrite ltR_subr_addl addRC. Qed.
+
 Lemma leR_addl x y : (x <= x + y) <-> (0 <= y).
 Proof. by rewrite -{1}(addR0 x) leR_add2l. Qed.
 Lemma leR_addr x y : (x <= y + x) <-> (0 <= y).

--- a/probability/convex.v
+++ b/probability/convex.v
@@ -744,7 +744,7 @@ Qed.
 
 Lemma convA'_oprob (r s : oprob) a b c :
   a <| [p_of r, s] |> (b <| [q_of r, s] |> c) = (a <| r |> b) <| s |> c.
-Proof. apply/convA'/oprob_neq1. Qed.
+Proof. exact/convA'/oprob_neq1. Qed.
 
 Import ScaledConvex.
 
@@ -764,7 +764,7 @@ Proof. by rewrite -{1}(convmm x q) convACA. Qed.
 
 Lemma convACA' (a b c d : T) (p q r : oprob) :
 (*
-  let p1 := (q * p)%:opr in 
+  let p1 := (q * p)%:opr in
   let p2 := (q.~ * r)%:opr in
   let r1 := (q * p.~)%:opr in
   let r2 := (q.~ * r.~)%:opr in

--- a/probability/convex.v
+++ b/probability/convex.v
@@ -742,6 +742,10 @@ move=> H; case/boolP : (s == 0%:pr) => s0.
 - by rewrite convA s_of_pqK // r_of_pqK.
 Qed.
 
+Lemma convA'_oprob (r s : oprob) a b c :
+  a <| [p_of r, s] |> (b <| [q_of r, s] |> c) = (a <| r |> b) <| s |> c.
+Proof. apply/convA'/oprob_neq1. Qed.
+
 Import ScaledConvex.
 
 Lemma convACA (a b c d : T) p q :
@@ -757,6 +761,27 @@ Qed.
 Lemma convDr (x y z : T) (p q : prob) :
   x <| p |> (y <| q |> z) = (x <| p |> y) <| q |> (x <| p |> z).
 Proof. by rewrite -{1}(convmm x q) convACA. Qed.
+
+Lemma convACA' (a b c d : T) (p q r : oprob) :
+(*
+  let p1 := (q * p)%:opr in 
+  let p2 := (q.~ * r)%:opr in
+  let r1 := (q * p.~)%:opr in
+  let r2 := (q.~ * r.~)%:opr in
+  let q' := ((p1 + p2) / (p1 + p2 + (r1 + r2)))%:opr in
+  let p' := (p1 / (p1 + p2))%:opr in
+  let r' := (r1 / (r1 + r2))%:opr in
+  (a <|p|> b) <|q|> (c <|r|> d) = (a <|p'|> c) <|q'|> (b <|r'|> d).
+*)
+  exists p' q' r', (a <|p|> b) <|q|> (c <|r|> d) = (a <|p'|> c) <|q'|> (b <|r'|> d).
+Proof.
+rewrite (convC _ _ p).
+rewrite convA convC !convA.
+set C0 := _.~%:pr; rewrite (_ : C0 = C0%:opr) //.
+set C1 := _.~%:pr; rewrite (_ : C1 = C1%:opr) //.
+rewrite -convA'_oprob (convC d) convC.
+by eexists; eexists; eexists; congr ((_ <|_|> _) <|_|> (_ <|_|> _)).
+Qed.
 
 Local Open Scope vec_ext_scope.
 
@@ -1336,7 +1361,7 @@ Proof. by move=> x /=; rewrite mul1R. Qed.
 Lemma scaleR_addpt : {morph scaleR : x y / addpt x y >-> (x + y)%R}.
 Proof.
 move=> [p x|] [q y|] /=; rewrite ?(add0R,addR0) //.
-rewrite avgRE /avg /Rpos_prob /= onem_div /Rdiv; last by apply Rpos_neq0.
+rewrite avgRE /avg /divRposxxy /= onem_div /Rdiv; last by apply Rpos_neq0.
 rewrite -!(mulRC (/ _)%R) mulRDr !mulRA mulRV; last by apply Rpos_neq0.
 by rewrite !mul1R (addRC p) addRK.
 Qed.

--- a/probability/fdist.v
+++ b/probability/fdist.v
@@ -831,7 +831,7 @@ Proof.
 rewrite q_of_rsE p_of_rsE.
 have->: r.~ * s / (r * s).~ = (s.~ / (r * s).~).~
   by rewrite /onem; field; move/eqP: (oprob_neq0 ((r * s).~)%:opr).
-apply onem_oprobb.
+apply onem_oprob.
 apply/andP; split; apply/ltRP.
 - by apply/divR_gt0/oprob_gt0/oprob_gt0.
 - apply/(@ltR_pmul2r (r * s).~); first by apply/oprob_gt0.

--- a/probability/fdist.v
+++ b/probability/fdist.v
@@ -637,22 +637,16 @@ Proof. by apply/fdist_ext => ?; rewrite dE -big_distrl /= FDist.f1 mul1R. Qed.
 End prop.
 End ConvnFDist.
 
-(* TODO: move to reals_ext.v? *)
-Lemma s_of_pq_prob (p q : prob) : 0 <= (p.~ * q.~).~ <= 1.
-Proof.
-move: p q => -[] p /= /andP [] /leRP p0 /leRP p1 -[] q /= /andP [] /leRP q0 /leRP q1.
-split; last first.
-  apply/onem_le1/mulR_ge0; exact/onem_ge0.
-apply/onem_ge0; rewrite -(mulR1 1); apply leR_pmul;
-  [exact/onem_ge0 | exact/onem_ge0 | exact/onem_le1 | exact/onem_le1].
-Qed.
-
 Definition s_of_pq (p q : prob) : prob := locked (p.~ * q.~).~%:pr.
 
 Notation "[ 's_of' p , q ]" := (s_of_pq p q) (format "[ 's_of'  p ,  q ]") : proba_scope.
 
 Lemma s_of_pqE (p q : prob) : [s_of p, q] = (p.~ * q.~).~ :> R.
 Proof. by rewrite /s_of_pq; unlock. Qed.
+
+Lemma s_of_pq_oprob (p q : oprob) : 0 <b [s_of p, q] <b 1.
+Proof. rewrite s_of_pqE (_ : (p.~ * q.~).~ = (p.~ * q.~).~%:opr) //=; exact: OProb.O1. Qed.
+Canonical oprob_of_s_of_pq (p q : oprob) := Eval hnf in OProb.mk (s_of_pq_oprob p q).
 
 Lemma s_of_p0 (p : prob) : [s_of p, 0%:pr] = p.
 Proof. by apply/val_inj; rewrite /= s_of_pqE onem0 mulR1 onemK. Qed.
@@ -669,22 +663,24 @@ move=> ?; rewrite s_of_pqE';
   apply addR_gt0wl; [exact/prob_gt0 | exact: mulR_ge0].
 Qed.
 
+Lemma s_of_gt0_oprob (p : oprob) (q : prob) : 0 < [s_of p, q].
+Proof. by apply/s_of_gt0/oprob_neq0. Qed.
+
 Lemma ge_s_of (p q : prob) : p <= [s_of p, q].
 Proof. rewrite s_of_pqE' addRC -leR_subl_addr subRR; exact/mulR_ge0. Qed.
 
-Lemma r_of_pq_prob (p q : prob) : 0 <= p / [s_of p, q] <= 1.
+Lemma r_of_pq_prob (p q : prob) : 0 <b= p / [s_of p, q] <b= 1.
 Proof.
 case/boolP : (p == 0%:pr :> prob) => p0.
-  rewrite (eqP p0) div0R; split => //; exact/leRR.
+  rewrite (eqP p0) div0R; apply/andP; split; apply/leRP => //; exact/leRR.
 case/boolP : (q == 0%:pr :> prob) => q0.
-  rewrite (eqP q0) (s_of_p0 p) divRR //; split => //; exact/leRR.
-split.
+  rewrite (eqP q0) (s_of_p0 p) divRR //; apply/andP; split; apply/leRP=> //; exact/leRR.
+apply/andP; split; apply/leRP.
 - apply divR_ge0 => //; exact/s_of_gt0.
 - rewrite leR_pdivr_mulr ?mul1R; [exact: ge_s_of | exact: s_of_gt0].
 Qed.
 
-Definition r_of_pq_ (p q : prob) := Eval hnf in Prob.mk_ (r_of_pq_prob p q).
-Definition r_of_pq (p q : prob) : prob := locked (r_of_pq_ p q).
+Definition r_of_pq (p q : prob) : prob := locked (Prob.mk (r_of_pq_prob p q)).
 
 (* TODO: move up? *)
 Notation "[ 'r_of' p , q ]" := (r_of_pq p q)
@@ -693,8 +689,22 @@ Notation "[ 'r_of' p , q ]" := (r_of_pq p q)
 Lemma r_of_pqE (p q : prob) : [r_of p, q] = p / [s_of p, q] :> R.
 Proof. by rewrite /r_of_pq; unlock. Qed.
 
+Lemma r_of_pq_oprob (p q : oprob) : 0 <b [r_of p, q] <b 1.
+Proof.
+rewrite r_of_pqE.
+apply/andP; split; apply/ltRP; first by apply divR_gt0.
+rewrite ltR_pdivr_mulr ?mul1R; last by apply/(oprob_gt0).
+rewrite ltR_neqAle; split; last by apply/ge_s_of.
+rewrite s_of_pqE'; apply/eqP/ltR_eqF/ltR_addl.
+by apply/oprob_gt0.
+Qed.
+Canonical oprob_of_r_of_pq (p q : oprob) := Eval hnf in OProb.mk (r_of_pq_oprob p q).
+
 Lemma r_of_p0 (p : prob) : p != 0%:pr -> [r_of p, 0%:pr] = 1%:pr.
 Proof. by move=> p0; apply val_inj; rewrite /= r_of_pqE s_of_p0 divRR. Qed.
+
+Lemma r_of_p0_oprob (p : oprob) : [r_of p, 0%:pr] = 1%:pr.
+Proof. by apply/r_of_p0/oprob_neq0. Qed.
 
 Lemma r_of_0q (q : prob) : [r_of 0%:pr, q] = 0%:pr.
 Proof. by apply/val_inj; rewrite /= r_of_pqE div0R. Qed.
@@ -718,15 +728,17 @@ rewrite (p_is_rs _ q) /= {1}s_of_pqE -H2 onemK r_of_pqE s_of_pqE.
 by rewrite -H2 onemK /Rdiv -mulRA mulVR ?mulR1.
 Qed.
 
-Lemma p_of_rs_prob (r s : prob) : 0 <= r * s <= 1.
+Lemma r_of_pq_is_r_oprob (p q : prob) (r s : oprob) :
+  p = r * s :> R -> s.~ = p.~ * q.~ -> [r_of p, q] = r.
+Proof. apply/r_of_pq_is_r/oprob_neq0/oprob_neq0. Qed.
+
+Lemma p_of_rs_prob (r s : prob) : 0 <b= r * s <b= 1.
 Proof.
 move: r s => -[] r /andP [] /leRP r0 /leRP r1 -[] s /= /andP [] /leRP s0 /leRP s1.
-split; [exact/mulR_ge0 | rewrite -(mulR1 1); exact: leR_pmul].
+apply/andP; split; apply/leRP; [exact/mulR_ge0 | rewrite -(mulR1 1); exact: leR_pmul].
 Qed.
 
-Definition p_of_rs_ (r s : prob) : prob :=
-  Eval hnf in Prob.mk_ (p_of_rs_prob r s).
-Definition p_of_rs (r s : prob) : prob := locked (p_of_rs_ r s).
+Definition p_of_rs (r s : prob) : prob := locked (Prob.mk (p_of_rs_prob r s)).
 
 (* TODO: move up? *)
 Notation "[ 'p_of' r , s ]" := (p_of_rs r s)
@@ -734,6 +746,10 @@ Notation "[ 'p_of' r , s ]" := (p_of_rs r s)
 
 Lemma p_of_rsE (r s : prob) : [p_of r, s] = r * s :> R.
 Proof. by rewrite /p_of_rs; unlock. Qed.
+
+Lemma p_of_rs_oprob (r s : oprob) : 0 <b [p_of r, s] <b 1.
+Proof. by rewrite p_of_rsE; apply/OProb.O1. Qed.
+Canonical oprob_of_p_of_rs (r s : oprob) := Eval hnf in OProb.mk (p_of_rs_oprob r s).
 
 Lemma p_of_r1 (r : prob) : [p_of r, 1%:pr] = r.
 Proof. by apply val_inj; rewrite /= p_of_rsE mulR1. Qed.
@@ -785,13 +801,13 @@ apply: (iffP idP);
   [by case/andP => /eqP -> /eqP -> | by case => -> ->; rewrite eqxx].
 Qed.
 
-Lemma q_of_rs_prob (r s : prob) : 0 <= (r.~ * s) / [p_of r, s].~ <= 1.
+Lemma q_of_rs_prob (r s : prob) : 0 <b= (r.~ * s) / [p_of r, s].~ <b= 1.
 Proof.
 case/boolP : (r == 1%:pr :> prob) => r1.
-  rewrite (eqP r1) onem1 mul0R div0R; split => //; exact/leRR.
+  rewrite (eqP r1) onem1 mul0R div0R; apply/andP; split; apply/leRP => //; exact/leRR.
 case/boolP : (s == 1%:pr :> prob) => s1.
-  rewrite (eqP s1) mulR1 p_of_r1 divRR ?onem_neq0 //; split=> //; exact/leRR.
-split.
+  rewrite (eqP s1) mulR1 p_of_r1 divRR ?onem_neq0 //; apply/andP; split; apply/leRP => //; exact/leRR.
+apply/andP; split; apply/leRP.
   apply/divR_ge0; first exact/mulR_ge0.
     apply/onem_gt0; rewrite p_of_rsE -(mulR1 1); apply/ltR_pmul => //;
       by [rewrite -prob_lt1 | rewrite -prob_lt1].
@@ -801,8 +817,7 @@ apply onem_gt0; rewrite p_of_rsE -(mulR1 1); apply/ltR_pmul => //;
   by [rewrite -prob_lt1 | rewrite -prob_lt1].
 Qed.
 
-Definition q_of_rs_ (r s : prob) : prob := Eval hnf in Prob.mk_ (q_of_rs_prob r s).
-Definition q_of_rs (r s : prob) : prob := locked (q_of_rs_ r s).
+Definition q_of_rs (r s : prob) : prob := locked (Prob.mk (q_of_rs_prob r s)).
 
 (* TODO: move up? *)
 Notation "[ 'q_of' r , s ]" := (q_of_rs r s)
@@ -810,6 +825,21 @@ Notation "[ 'q_of' r , s ]" := (q_of_rs r s)
 
 Lemma q_of_rsE (r s : prob) : [q_of r, s] = (r.~ * s) / [p_of r, s].~ :> R.
 Proof. by rewrite /q_of_rs; unlock. Qed.
+
+Lemma q_of_rs_oprob (r s : oprob) : 0 <b [q_of r, s] <b 1.
+Proof.
+rewrite q_of_rsE p_of_rsE.
+have->: r.~ * s / (r * s).~ = (s.~ / (r * s).~).~
+  by rewrite /onem; field; move/eqP: (oprob_neq0 ((r * s).~)%:opr).
+apply onem_oprobb.
+apply/andP; split; apply/ltRP.
+- by apply/divR_gt0/oprob_gt0/oprob_gt0.
+- apply/(@ltR_pmul2r (r * s).~); first by apply/oprob_gt0.
+  rewrite divRE mulRAC -mulRA mulRV ?oprob_neq0 // mulR1 mul1R.
+  rewrite -onem_lt.
+  by rewrite -{2}(mul1R s) ltR_pmul2r; [apply/oprob_lt1 | apply/oprob_gt0].
+Qed.
+Canonical oprob_of_q_of_rs (r s : oprob) := Eval hnf in OProb.mk (q_of_rs_oprob r s).
 
 Lemma q_of_r0 (r : prob) : [q_of r, 0%:pr] = 0%:pr.
 Proof. by apply/val_inj => /=; rewrite q_of_rsE mulR0 div0R. Qed.
@@ -843,6 +873,9 @@ rewrite subR_eq0; apply/eqP; apply: contra H => /eqP rs1.
 by apply/eqP/val_inj; rewrite /= p_of_rsE.
 Qed.
 
+Lemma s_of_pqK_oprob (r s : oprob) : [s_of [p_of r, s], [q_of r, s]] = s.
+Proof. apply/s_of_pqK/oprob_neq1. Qed.
+
 Lemma r_of_pqK (r s : prob) : [p_of r, s] != 1%:pr -> s != 0%:pr ->
   [r_of [p_of r, s], [q_of r, s]] = r.
 Proof.
@@ -854,6 +887,9 @@ rewrite subR_eq0 => /esym.
 apply/eqP; apply: contra H1 => /eqP H1.
 by apply/eqP/val_inj; rewrite /= p_of_rsE.
 Qed.
+
+Lemma r_of_pqK_oprob (r s : oprob) : [r_of [p_of r, s], [q_of r, s]] = r.
+Proof. apply/r_of_pqK/oprob_neq0/oprob_neq1. Qed.
 
 Module ConvFDist.
 Section def.


### PR DESCRIPTION
This PR renews the implementation of `necset_convType` in terms of `conv_set` rather than defining another similar but different convex combination operation.

As a byproduct, this PR also contains all of boolean_prob branch and a module for open intervals ( `Module OProb` ).
The latter simplifies some computations that appear when handling convexity.
