### PR TITLE
improve Affine and BiglubMorph definitions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,31 @@ from 0.3 to ???
 - added:
   + lemmas prob_ge0, prob_le1 (also as Hint Resolve)
 
+- renamed:
+  + Module AffineFunction -> Affine
+  + Notation AffineFunction -> Affine
+  + Notation affine_function -> affine
+  + affine_functionP' -> affine_conv
+- removed:
+  + affine_function_at
+  + image_preserves_convex_hull', is_convex_set_image'
+- added:
+  + Notations [affine of f] and [affine of f as g]
+  + Notation biglub_morph
+- changed:
+  + affine_function_id_proof/affine_function_id ->
+      idfun_is_affine/Canonical idfun_affine
+  + affine_function_comp_proof'/affine_function_comp_proof/affine_function_comp ->
+      comp_is_affine/Canonical comp_affine
+  + in Section with_affine_projection and Section S1_proj_Convn_finType
+    * prj/prj_affine -> prj : {affine ... -> ...}
+  + Convn_of_FSDist_FSDistfmap -> to use {affine ...}
+- changed:
+  + biglub_morph, biglub_lub_morp -> to use {Biglub_morph ...}
+  + multiple inheritance in Module BiglubMorph
+  + biglub_affine_id_proof -> idfun_is_biglub_affine/Canonical idfun_is_biglub_affine
+  + biglub_affine_comp_proof -> comp_is_biglub_affine/Canonical comp_biglub_affine
+
 -----------------
 from 0.2.2 to 0.3
 -----------------

--- a/information_theory/convex_fdist.v
+++ b/information_theory/convex_fdist.v
@@ -361,9 +361,10 @@ apply R_concave_functionB.
   destruct t.
   rewrite /Conv /=. (* TODO *)
   rewrite -ProdFDist.snd_convex; exact/leRR.
-- suff : affine_function (fun x : fdist_convType _ => CondEntropy.h (Swap.d (CJFDist.make_joint x Q))) by move /affine_functionP => [].
-  move => p q t.
-  rewrite /affine_function_at /= avgRE /CondEntropy.h /CondEntropy.h1.
+- suff : affine (fun x => CondEntropy.h (Swap.d (CJFDist.make_joint x Q))).
+   by move=> /affine_functionP[].
+  move=> t p q.
+  rewrite /= avgRE /CondEntropy.h /CondEntropy.h1.
   rewrite 2!big_distrr -big_split /=; apply eq_bigr => a _.
   rewrite !Swap.snd !Bivar.fstE !mulRN -oppRD; congr (- _).
   rewrite !big_distrr -big_split /=; apply eq_bigr => b _.

--- a/probability/convex_stone.v
+++ b/probability/convex_stone.v
@@ -1083,19 +1083,20 @@ Qed.
 End convex_space_prop.
 
 Section affine_function_prop0.
-Lemma affine_function_Sum (A B : convType) (f : {affine A -> B}) (n : nat) (g : 'I_n -> A) (e : {fdist 'I_n}) :
+Lemma affine_function_Sum (A B : convType) (f : {affine A -> B}) (n : nat)
+    (g : 'I_n -> A) (e : {fdist 'I_n}) :
   f (<|>_e g) = <|>_e (f \o g).
 Proof.
 elim: n g e => [g e|n IH g e]; first by move: (fdistI0_False e).
 case/boolP : (e ord0 == 1%R :> R) => [|e01].
   by rewrite FDist1.dE1 => /eqP ->; rewrite 2!ConvnFDist1.
-by rewrite 2!convnE (affine_functionP' f) IH.
+by rewrite 2!convnE affine_conv IH.
 Qed.
 End affine_function_prop0.
 
 Section convn_convnfdist.
 Variable A : finType.
-Lemma convn_convnfdist (n : nat) (g : 'I_n -> fdist_convType A) (d : {fdist 'I_n}) :
+Lemma convn_convnfdist n (g : 'I_n -> fdist_convType A) (d : {fdist 'I_n}) :
   <|>_d g = ConvnFDist.d d g.
 Proof.
 elim: n g d => /= [g d|n IH g d]; first by move: (fdistI0_False d).


### PR DESCRIPTION
- rename AffineFunction to Affine to be shorter and closer to MathComp
  + and propagate
- fix and reveal [affine ...] notations
  + scoping was making id point to Coq reals!
  + we can now use the notation in convex and monae
- move affine_function_at to inside Module Affine
  + it caused useless unfoldings
  + it now uses the morph notation
  + it is recovered as the affine_conv lemma which is now
    used more efficiently
- removed a few occurrences of affine hypotheses in favor of {affine _ -> _}
  + together with changes above, this improves automatic inference and
    therefore shortens proofs
  + see for example the removal of image_preserves_convex_hull' and
    is_convex_set_image' or changes in sections with_affine_projection
    and Section S1_proj_Convn_finType
- replace affine_function_{id,comp} with more disciplined {idfun,comp}_affine
  + on the model of MathComp
- also move biglub_morph inside Module BiglubMorph
- fix multiple inheritance in Module BiglubMorph

@t6s 