### PR TITLE
add redirections to removed items in changedlog.txt

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -32,9 +32,9 @@ from 0.3.4 to 0.3.5
 * changed:
 - row_nth moved and renamed to bitseq_row_nth
 * removed:
-  + sumR_setT
-  + eq_imagel
-  + eq_bigcup
+  + sumR_setT (use finset.big_set in MathComp)
+  + eq_imagel (use classical_sets.eq_imagel in MathComp-Analysis)
+  + eq_bigcup (use classical_sets.eq_bigcup in MathComp-Analysis)
 
 -------------------
 from 0.3.3 to 0.3.4


### PR DESCRIPTION
`changelog.txt` currently lists removed Definitions / Lemmas / etc. but not what to use instead, making the user stuck at upgrading their scripts dependent on the removed things.

This draft PR is an attempt to add comments to previously removed items.
I am not sure how thoroughly this should be done, thus just a draft.