### PR TITLE
Carathéodory

### DIFF
--- a/probability/convex.v
+++ b/probability/convex.v
@@ -1446,8 +1446,6 @@ Qed.
 
 Definition unsplit_prod (m n: nat) (i:'I_m * 'I_n): 'I_(m*n) := let (i, j) := i in Ordinal (unsplit_prodp i j).
 
-From mathcomp Require Import div.
-
 (* TODO: shall we extend the lemmas on Nat.div to divn ? *)
 Definition split_prodpl (m n : nat) (i : 'I_(m * n)): (i %/ n < m)%nat.
 Proof.
@@ -1726,6 +1724,7 @@ by rewrite scalerA /= -scalerDl; congr scale; rewrite addrC mulNr ffunE.
 Qed.
 End caratheodory.
 Section linear_affine.
+Open Scope ring_scope.
 Variable E F: lmodType R.
 Variable f: {linear E -> F}.
 Import GRing.

--- a/probability/convex.v
+++ b/probability/convex.v
@@ -1497,7 +1497,6 @@ End split_prod.
 (* TODO: Lemma preim_cancel: ... *)
 
 Lemma avgnr_add n m (f: 'I_n -> E) (d: {fdist 'I_n}) (g: 'I_m -> E) (e: {fdist 'I_m}): <|>_d f + <|>_e g = <|>_(FDistMap.d (@unsplit_prod n m) (ProdFDist.d d (fun _ => e))) (fun i=> let (i, j) := split_prod i in f i + g j).
-Search {fdist _}.
 Proof.
 rewrite -[<|>_e g]scale1r !avgnrE !/avgnr big_prod_ord. 
 have<-: 1%R = 1 by [].
@@ -1678,11 +1677,9 @@ wlog: g d gA mu muR muE im muip muim / (im == ord0)%N.
   FDistMap.d f' d (f' im) / mu (f' (f' im)) <= FDistMap.d f' d j / mu (f' j).
       move=>j /muim.
       rewrite fcan' FDistMap.dE (big_pred1 im) /=; last first.
-        (* NB* was proved using axiomatized image_mem_pred1 *)
         move=> i; apply/idP/idP; rewrite !inE; last by move=> /eqP ->.
         by move=> /eqP /(bij_inj fbij) /eqP.
       rewrite FDistMap.dE (big_pred1 (f' j)) //.
-      (* NB: was proved using axiomatized image_mem_pred1 *)
       by move=> /= i; apply/idP/idP; rewrite !inE => /eqP;
         [move=> <-; rewrite fcan' | move=> ->; rewrite fcan'].
    move=>/(_ muim').

--- a/probability/convex.v
+++ b/probability/convex.v
@@ -1,7 +1,7 @@
 (* infotheo: information theory and error-correcting codes in Coq             *)
 (* Copyright (C) 2020 infotheo authors, license: LGPL-2.1-or-later            *)
 From HB Require Import structures.
-From mathcomp Require Import all_ssreflect ssralg fingroup perm finalg matrix.
+From mathcomp Require Import all_ssreflect ssrnum ssralg fingroup perm finalg matrix vector.
 From mathcomp Require Import boolp classical_sets Rstruct.
 From mathcomp Require Import ssrnum ereal.
 Require Import Reals.
@@ -266,7 +266,7 @@ End convex_space_lemmas.
 
 Section segment.
 Variable A: convType.
-Definition segment (x y: A) := image (@setT prob) (fun p => Conv p x y).
+Definition segment (x y: A) := image (@setT prob) (fun p => conv p x y).
 
 Lemma segment_sym u v x : segment u v x -> segment v u x.
 Proof. by move=> [p _ <-]; exists (p.~%:pr); rewrite -?convC. Qed.
@@ -732,7 +732,7 @@ Lemma convA' (r s : prob) a b c : a <| [p_of r, s] |> (b <| [q_of r, s] |> c) = 
 Proof.
 case H: ([p_of r, s] == 1%:pr).
    move: H=>/p_of_rs1P [ -> -> ].
-   by rewrite conv1 conv1 -{2}(conv1 a (b <|[q_of (1)%:pr, (1)%:pr]|> c)); congr Conv; rewrite p_of_1s.
+   by rewrite conv1 conv1 -{2}(conv1 a (b <|[q_of (1)%:pr, (1)%:pr]|> c)); congr conv; rewrite p_of_1s.
 move: H=>/negP/negP H; case/boolP : (s == 0%:pr) => s0.
 - by rewrite (eqP s0) p_of_r0 conv0 q_of_r0 conv0 conv0.
 - by rewrite convA s_of_pqK // r_of_pqK.
@@ -769,9 +769,9 @@ Lemma convACA' (a b c d : T) (p q r : prob) :
 Proof.
 rewrite (convC p).
 rewrite convA convC !convA.
-set C0 := _.~%:pr; rewrite (_ : C0 = C0%:opr) //.
-set C1 := _.~%:pr; rewrite (_ : C1 = C1%:opr) //.
-rewrite -convA'_oprob (convC _ d) convC.
+set C0 := _.~%:pr.
+set C1 := _.~%:pr.
+rewrite -convA' (convC _ d) convC.
 by eexists; eexists; eexists; congr ((_ <|_|> _) <|_|> (_ <|_|> _)).
 Qed.
 
@@ -1388,8 +1388,8 @@ rewrite 2!scalerA; congr scale.
 have ->: p.~ * q = (p.~ * q)%R by [].
 by rewrite pq_is_rs -/r -/s mulrC.
 Qed.
-Definition lmodR_convMixin := ConvexSpace.Mixin avg1 avgI avgC avgA.
-Canonical lmodR_convType := ConvexSpace.Pack (ConvexSpace.Class lmodR_convMixin).
+HB.instance Definition _ (*lmodR_convType*) := @isConvexSpace.Build E (Choice.class _) _ avg1 avgI avgC avgA.
+
 Lemma avgrE p (x y : E) : x <| p |> y = avg p x y. Proof. by []. Qed.
 End lmodR_convex_space.
 Section lmodR_convex_space.
@@ -1408,7 +1408,7 @@ Proof. by move=> x ? ?; rewrite avgrE scalerDl -2!scalerA. Qed.
 (* Introduce morphisms to prove avgnE *)
 Import ScaledConvex.
 Definition scaler x : E := if x is Scaled p y then (Rpos.v p) *: y else 0.
-Lemma Scaled1rK : cancel (@S1 (lmodR_convType E)) scaler.
+Lemma Scaled1rK : cancel (@S1 (_ E)) scaler.
 Proof. by move=> x /=; rewrite scale1r. Qed.
 Lemma scaler_addpt : {morph scaler : x y / addpt x y >-> (x + y)}.
 Proof.
@@ -2465,7 +2465,7 @@ rewrite eqEsubset; split.
          by move: (hull_is_convex A)=>/asboolP; apply.
       exists (bx <|p|> by')=>//.
       by move: (hull_is_convex B)=>/asboolP; apply.
-   by apply (@hull_sub_convex _ _ (CSet.Pack (CSet.Mixin conv))), image2_subset; apply (@subset_hull (lmodR_convType T)).
+   by apply (@hull_sub_convex _ _ (CSet.Pack (CSet.Mixin conv))), image2_subset; exact (@subset_hull _ _).
 move=>x [a [na [ga [da [gaA ->]]]]] [b [nb [gb [db [gbB ->]]]]] <-.
 rewrite avgnr_add.
 exists (na * nb)%nat, (fun i => let (i, j) := split_prod i in ga i + gb j), (FDistMap.d (unsplit_prod (n:=nb)) da `x db); split=>// y [i _ <-].

--- a/probability/convex.v
+++ b/probability/convex.v
@@ -308,9 +308,9 @@ HB.mixin Record isAffine (U V : convType) (f : U -> V) := {
 HB.structure Definition Affine (U V : convType) :=
   {f of isAffine U V f}.
 
-Notation "{ 'affine'  T '->'  R }" :=
+Notation "{ 'affine' T '->' R }" :=
   (Affine.type T R) (at level 36, T, R at next level,
-    format "{ 'affine'  T  '->'  R }") : convex_scope.
+    format "{ 'affine' T  '->' R }") : convex_scope.
 
 Section affine_function_prop0.
 Variables (U V W : convType) (f : {affine V -> W}) (h : {affine U -> V}).
@@ -1694,7 +1694,7 @@ Variable f: {linear E -> F}.
 Import GRing.
 Lemma linear_is_affine: affine f.
 Proof. by move=>p x y; rewrite linearD 2!linearZZ. Qed.
-Canonical linear_affine := Affine linear_is_affine.
+HB.instance Definition _ (*linear_affine*) := isAffine.Build _ _ f linear_is_affine.
 End linear_affine.
 
 (* TOTHINK: Should we keep this section, only define R_convType, or something else ? *)

--- a/probability/convex.v
+++ b/probability/convex.v
@@ -7,6 +7,7 @@ From mathcomp Require Import ssrnum ereal.
 Require Import Reals.
 Require Import ssrR Reals_ext Ranalysis_ext ssr_ext ssralg_ext logb Rbigop.
 Require Import fdist jfdist.
+Import Order.POrderTheory Num.Theory.
 
 (******************************************************************************)
 (*                              Convexity                                     *)
@@ -262,6 +263,23 @@ Proof.
 by rewrite convC /= (_ : _ %:pr = 1%:pr) ?conv1 //; apply/val_inj/onem0.
 Qed.
 End convex_space_lemmas.
+
+Section segment.
+Variable A: convType.
+Definition segment (x y: A) := image (@setT prob) (fun p => Conv p x y).
+
+Lemma segment_sym u v x : segment u v x -> segment v u x.
+Proof. by move=> [p _ <-]; exists (p.~%:pr); rewrite -?convC. Qed.
+
+Lemma segmentC u v : segment u v = segment v u.
+Proof. by rewrite eqEsubset; split=>x; apply segment_sym. Qed.
+
+Lemma segmentL x y : segment x y x.
+Proof. by exists 1%:pr; rewrite ?conv1. Qed.
+
+Lemma segmentR x y : segment x y y.
+Proof. by exists 0%:pr; rewrite ?conv0. Qed.
+End segment.
 
 Section convn.
 Variable A : convType.
@@ -710,17 +728,15 @@ rewrite convA; congr ((_ <| _ |> _) <| _ |> _).
 by rewrite (@r_of_pq_is_r  _ _ r s).
 Qed.
 
-Lemma convA' (r s : prob) a b c : [p_of r, s] != 1%:pr ->
-  a <| [p_of r, s] |> (b <| [q_of r, s] |> c) = (a <| r |> b) <| s |> c.
+Lemma convA' (r s : prob) a b c : a <| [p_of r, s] |> (b <| [q_of r, s] |> c) = (a <| r |> b) <| s |> c.
 Proof.
-move=> H; case/boolP : (s == 0%:pr) => s0.
+case H: ([p_of r, s] == 1%:pr).
+   move: H=>/p_of_rs1P [ -> -> ].
+   by rewrite conv1 conv1 -{2}(conv1 a (b <|[q_of (1)%:pr, (1)%:pr]|> c)); congr Conv; rewrite p_of_1s.
+move: H=>/negP/negP H; case/boolP : (s == 0%:pr) => s0.
 - by rewrite (eqP s0) p_of_r0 conv0 q_of_r0 conv0 conv0.
 - by rewrite convA s_of_pqK // r_of_pqK.
 Qed.
-
-Lemma convA'_oprob (r s : oprob) a b c :
-  a <| [p_of r, s] |> (b <| [q_of r, s] |> c) = (a <| r |> b) <| s |> c.
-Proof. exact/convA'/oprob_neq1. Qed.
 
 Import ScaledConvex.
 
@@ -738,7 +754,7 @@ Lemma convDr (x y z : T) (p q : prob) :
   x <| p |> (y <| q |> z) = (x <| p |> y) <| q |> (x <| p |> z).
 Proof. by rewrite -{1}(convmm q x) convACA. Qed.
 
-Lemma convACA' (a b c d : T) (p q r : oprob) :
+Lemma convACA' (a b c d : T) (p q r : prob) :
 (*
   let p1 := (q * p)%:opr in
   let p2 := (q.~ * r)%:opr in
@@ -932,6 +948,27 @@ have [/eqP d01|d0n1] := boolP (d ord0 == 1%R).
 rewrite !convnE !IHn.
 congr Convn; apply funext=> i.
 by rewrite convDr.
+Qed.
+
+Lemma convnDl:
+  forall (n : nat) (p : prob) (x : T) (g : 'I_n -> T) (d : {fdist 'I_n}),
+    <|>_d g <|p|> x = <|>_d (fun i => g i <|p|> x).
+Proof.
+move=> p x g d e.
+rewrite convC convnDr; apply eq_convn=>// i.
+by rewrite -convC.
+Qed.
+
+Lemma convnDlr:
+  forall (n m : nat) (p : prob) (f : 'I_n -> T) (d : {fdist 'I_n}) (g: 'I_m -> T) (e: {fdist 'I_m}),
+    <|>_d f <|p|> <|>_e g = <|>_(AddFDist.d d e p) (fun i => match fintype.split i with inl i => f i | inr i => g i end).
+Proof.
+move=>n m p f d g e.
+apply S1_inj; rewrite S1_conv S1_convn S1_convn S1_convn convptE big_scalept big_scalept big_split_ord; congr addpt; apply congr_big=>// i _; rewrite scalept_comp // AddFDist.dE /fintype.split; case ltnP=>ilt.
+   2: by exfalso; move: ilt=>/=; rewrite leqNgt=>/negP.
+   2: by exfalso; move: ilt=>/=; rewrite addnC {2}[n]/(0+n) -/addn ltn_add2r ltn0.
+   by have ->: Ordinal ilt = i by apply val_inj.
+by have ->: Ordinal (split_subproof ilt) = i by apply val_inj; rewrite /= addnC {2}[n]/(0+n) -/addn subnDr /subn /subn_rec Nat.sub_0_r.
 Qed.
 
 End convex_space_prop2.
@@ -1151,6 +1188,13 @@ rewrite convptE big_split_ord !big_scalept /=.
 congr addpt; apply eq_bigr => i _;
   rewrite (scalept_comp (S1 _) (prob_ge0 _) (FDist.ge0 _ _));
   by rewrite AddFDist.dE (split_lshift,split_rshift).
+Qed.
+
+Lemma segment_is_convex (x y: A): is_convex_set (segment x y).
+Proof.
+apply/asboolP=>u v p [q _ <-] [r _ <-].
+move: (convACA' x y x y q p r)=>[q' [p' [r' ->]]].
+by rewrite convmm convmm; exists p'.
 Qed.
 
 Lemma hull_is_convex (Z : set A) : is_convex_set (hull Z).

--- a/probability/convex.v
+++ b/probability/convex.v
@@ -1446,26 +1446,19 @@ Qed.
 
 Definition unsplit_prod (m n: nat) (i:'I_m * 'I_n): 'I_(m*n) := let (i, j) := i in Ordinal (unsplit_prodp i j).
 
+From mathcomp Require Import div.
+
 (* TODO: shall we extend the lemmas on Nat.div to divn ? *)
-Definition split_prodpl (m n: nat) (i: 'I_(m*n)): (Nat.div i n < m)%nat.
+Definition split_prodpl (m n : nat) (i : 'I_(m * n)): (i %/ n < m)%nat.
 Proof.
-case: i=>[i ilt].
-case: m ilt=>[| m] ilt.
-   by exfalso; move: ilt; rewrite /muln /muln_rec ltn0.
-case: n ilt=>[| n] ilt.
-   by exfalso; move: ilt; rewrite mulnC /muln /muln_rec ltn0.
-apply /leP; apply PeanoNat.Nat.div_lt_upper_bound=>//=.
-by move: ilt; rewrite mulnC=>/leP.
+move: n i => [i|n i]; last by rewrite ltn_divLR.
+by rewrite divn0; move: i; rewrite muln0 => -[].
 Qed.
 
-Definition split_prodpr (m n: nat) (i: 'I_(m*n)): (Nat.modulo i n < n)%nat.
+Definition split_prodpr (m n : nat) (i : 'I_(m * n)): (i %% n < n)%nat.
 Proof.
-case: i=>[i ilt].
-case: m ilt=>[| m] ilt.
-   by exfalso; move: ilt; rewrite /muln /muln_rec ltn0.
-case: n ilt=>[| n] ilt.
-   by exfalso; move: ilt; rewrite mulnC /muln /muln_rec ltn0.
-by apply /leP; apply PeanoNat.Nat.mod_upper_bound.
+move: n i => [i|n i]; last by rewrite ltn_pmod.
+by exfalso; move: i; rewrite muln0 => -[].
 Qed.
 
 Definition split_prod (m n: nat) (i: 'I_(m*n)): 'I_m * 'I_n := (Ordinal (split_prodpl i), Ordinal (split_prodpr i)).
@@ -1490,27 +1483,14 @@ have e: forall j, rshift n (unsplit_prod (i, j)) = Ordinal (unsplit_prodp (lift 
 by apply congr_big=>// [ j | j _ ]; f_equal.
 Qed.
 
-Lemma split_prodK (n m: nat): cancel (@split_prod n m) (@unsplit_prod n m).
-Proof.
-move=> [i ilt].
-apply val_inj=>/=.
-apply/esym; rewrite mulnC /muln /muln_rec /addn /addn_rec.
-by apply PeanoNat.Nat.div_mod_eq.
-Qed.
+Lemma split_prodK n m : cancel (@split_prod n m) (@unsplit_prod n m).
+Proof. by move=> i; apply val_inj => /=; rewrite -divn_eq. Qed.
 
-Lemma unsplit_prodK (n m: nat): cancel (@unsplit_prod n m) (@split_prod n m).
+Lemma unsplit_prodK n m : cancel (@unsplit_prod n m) (@split_prod n m).
 Proof.
-move=> [[i ilt] [j jlt]].
-apply pair_equal_spec; split; apply val_inj=>/=.
-   rewrite /muln /muln_rec /addn /addn_rec PeanoNat.Nat.div_add_l.
-      2: by move=>m0; subst m; move: jlt; rewrite ltn0.
-   rewrite PeanoNat.Nat.div_small.
-      2: by apply /leP.
-   by apply/esym; apply plus_n_O.
-rewrite addnC /muln /muln_rec /addn /addn_rec PeanoNat.Nat.mod_add.
-   2: by move=>m0; subst m; move: jlt; rewrite ltn0.
-rewrite PeanoNat.Nat.mod_small=>//.
-by apply /leP.
+move: m => [[? [[]]]//|m [i j]]; congr (_, _); apply/val_inj => /=.
+- by rewrite divnMDl// divn_small// addn0.
+- by rewrite modnMDl modn_small.
 Qed.
 End split_prod.
 
@@ -1623,9 +1603,6 @@ apply/eqP/eqP.
 by move=>->.
 Qed.
 
-Lemma image_mem_pred1 (aT: finType) (rT: eqType) (f: aT -> rT) (x: aT): simpl_of_mem (mem (image_mem f (mem (PredOfSimpl.coerce (pred1 x))))) = pred1 (f x).
-Proof. admit. Admitted.
-
 Lemma caratheodory (A: set (Vector.lmodType E)) x: x \in hull A -> exists (n : nat) (g : 'I_n -> (Vector.lmodType E)) (d : {fdist 'I_n}), (n <= (dimv (@fullv R_fieldType E)).+1)%nat /\ range g `<=` A /\ x = <|>_d g.
 Proof.
 move=>/set_mem [n [g [d [gA ->]]]].
@@ -1700,10 +1677,14 @@ wlog: g d gA mu muR muE im muip muim / (im == ord0)%N.
   0 < mu (f' j) ->
   FDistMap.d f' d (f' im) / mu (f' (f' im)) <= FDistMap.d f' d j / mu (f' j).
       move=>j /muim.
-      rewrite fcan' FDistMap.dE (big_pred1 im) /=.
-         2: by move: (@pre_image _ _ f' (bij_inj fbij) (pred1 im))=>/funext/=; rewrite image_mem_pred1=>->.
+      rewrite fcan' FDistMap.dE (big_pred1 im) /=; last first.
+        (* NB* was proved using axiomatized image_mem_pred1 *)
+        move=> i; apply/idP/idP; rewrite !inE; last by move=> /eqP ->.
+        by move=> /eqP /(bij_inj fbij) /eqP.
       rewrite FDistMap.dE (big_pred1 (f' j)) //.
-      by rewrite -{1}[j]fcan'; move: (@pre_image _ _ f' (bij_inj fbij) (pred1 (f' j)))=>/funext/=; rewrite image_mem_pred1=>->.
+      (* NB: was proved using axiomatized image_mem_pred1 *)
+      by move=> /= i; apply/idP/idP; rewrite !inE => /eqP;
+        [move=> <-; rewrite fcan' | move=> ->; rewrite fcan'].
    move=>/(_ muim').
    have im0: f' im == ord0.
       by apply /eqP; apply val_inj=>/=; rewrite /f; rewrite eq_refl.
@@ -2438,7 +2419,7 @@ Qed.
 Lemma preimage_subset_convex_hull (f: {affine T -> U}) (Z: set U): hull (f @^-1` Z) `<=` f @^-1` (hull Z).
 Proof.
 move=>x [n [g [d [gZ ->]]]] /=.
-rewrite affine_function_Sum. 
+rewrite affine_function_Sum.
 exists n, (f \o g), d; split=>//.
 by move=>y [i _ <-]; apply gZ; exists i.
 Qed.
@@ -2511,7 +2492,7 @@ exists (x-<|>_d h).
    by apply subset_hull=>/=; rewrite linearB affine_function_Sum fx subrr.
 by rewrite addrC -addrA [-_+_]addrC subrr addr0.
 Qed.
-End affine_function_image.
+End linear_function_image.
 
 Section R_affine_function_prop.
 Variables (T : convType) (f : T -> R).

--- a/probability/convex.v
+++ b/probability/convex.v
@@ -2426,15 +2426,15 @@ Local Open Scope ring_scope.
 Variables T U : lmodType R.
 
 (* TODO: rename, move to mathcomp *)
-Lemma factorize_range (A B C: Type) (f: B -> C) (g: A -> C): range g `<=` range f -> exists h: A -> B, g = f \o h.
+Lemma factorize_range (A B C : Type) (f : B -> C) (g : A -> C) :
+  range g `<=` range f ->
+  exists h : A -> B, g = f \o h.
 Proof.
-move=>sub.
-simple refine (ex_intro _ _ _).
-   move=>a.
-   have: range f (g a) by apply sub; exists a.
-   move=>/= /cid2 [b _ _]; exact b.
-rewrite /ssr_have /=; apply funext=>a /=.
-by case: cid2.
+move=> gf; have [h gfh] : {h & forall a, g a = f (h a)}.
+  apply: (@choice _ _ (fun a b => g a = f b)) => a.
+  have /cid2[b _ <-] : range f (g a) by apply gf; exists a.
+  by exists b.
+by exists h; apply/funext => a; rewrite gfh.
 Qed.
 
 (* TODO: move to mathcomp *)

--- a/probability/convex.v
+++ b/probability/convex.v
@@ -1536,6 +1536,217 @@ move=>/(f_equal (@split_prod n m))/=.
 by rewrite (unsplit_prodK (i, j)) (unsplit_prodK (i', j'))=>/pair_equal_spec [ii' jj']; split; apply /eqP.
 Qed.
 End lmodR_convex_space.
+Section caratheodory.
+Variable E: vectType R.
+Local Open Scope ring_scope.
+Local Open Scope classical_set_scope.
+Import GRing.
+
+Lemma size_index_enum (T: finType): size (index_enum T) = #|T|.
+Proof. by rewrite cardT enumT. Qed.
+
+Lemma index_enum_cast_ord n m (e: n = m): index_enum (ordinal_finType m) = [seq (cast_ord e i) | i <- index_enum (ordinal_finType n)].
+Proof.
+subst m.
+rewrite -{1}(map_id (index_enum (ordinal_finType n))).
+apply eq_map=>[[x xlt]].
+rewrite /cast_ord; congr Ordinal; apply bool_irrelevance.
+Qed.
+
+(*TODO: move to mathcomp. *)
+(*TODO: find a non-ugly proof. *)
+
+Lemma freeN_combination n (s: n.-tuple E): ~free s -> exists k: 'I_n -> R, (\sum_i k i *: s`_i = 0) /\ exists i, k i != 0.
+Proof.
+move=>/negP; rewrite freeNE=>/existsP [[i ilt] /coord_span /= sin].
+move: (ilt) s sin; (have ne: (n = i.+1 + (n-i.+1))%nat by rewrite subnKC); rewrite ne=> ilt' s sin.
+simple refine (let k: 'I_(i.+1 + (n - i.+1)) -> R := _ in _).
+   move=>/fintype.split; case=> [[j jlt] | [j jlt]].
+      exact (if j == i then 1%R else 0%R).
+   refine (-%R (coord (drop_tuple i.+1 s) (@Ordinal _ j _) s`_i)).
+   rewrite addnC -{3}[i.+1]/(0+i.+1)%nat subnDr.
+   by have->: (n-i.+1-0 = n-i.+1)%nat by move: PeanoNat.Nat.sub_0_r.
+simpl in k; exists k; split.
+   2:{ exists (Ordinal ilt'); rewrite /k.
+   move: (splitP (Ordinal ilt')).
+   case: (fintype.split _)=>o sp; inversion sp; subst o.
+      by case: j H1 {sp}=> j jlt /= ->; rewrite eq_refl; apply oner_neq0.
+   by move: H0; rewrite leqnn.
+   }
+rewrite big_split_ord big_ord_recr (congr_big (index_enum (ordinal_finType i)) (fun _ => true) (fun i => 0 *: 0)%R) //.
+rewrite -scaler_suml scaler0.
+   2:{ move=> [j jlt] _; rewrite /k.
+   move: (splitP (lshift (n - i.+1) (widen_ord (leqnSn i) (Ordinal jlt)))).
+   case fintype.split=>o; move=>sp; inversion sp; subst o.
+      case: j0 H1 {sp}=> j0 j0lt /=<-.
+      case ji: (j == i).
+         by move: ji (jlt)=>/eqP ji; subst j; rewrite ltnn.
+      by do 2 rewrite scale0r.
+   by move: H0=>/esym; rewrite ltnNge=>/negP/negP; rewrite ltnNge=>/negP jle; elim jle; apply ltnW.
+   }
+move: (splitP (lshift (n - i.+1) (@ord_max i))); rewrite {1}/k; case fintype.split=>o sp; inversion sp; subst o.
+   2: by move: H0; rewrite leqnn.
+case: j H1 {sp}=> j jlt /=<-; rewrite eq_refl.
+clear j jlt H0.
+rewrite add0r scale1r.
+suff: (\sum_(i1 < n - i.+1) k (rshift i.+1 i1) *: s`_(i.+1 + i1) = - s`_i)
+   by move=>->; apply subrr.
+rewrite sin -sumrN.
+have ne': (i.+1 + (n - i.+1) - i.+1 = n - i.+1)%nat by rewrite -ne.
+rewrite (index_enum_cast_ord ne') big_map; apply congr_big=>// [[x xlt]] _.
+rewrite nth_drop -scaleNr; congr (_ *: _).
+move: (splitP (rshift i.+1 (cast_ord ne' (Ordinal xlt)))); rewrite /k; case: fintype.split=>o sp; inversion sp; subst o.
+   by move: H0; rewrite ltnNge leq_addr.
+case: k0 H1 sp=>k0 k0lt H1 sp; congr (- coord _ _ _).
+apply val_inj=>/=; apply /esym.
+move: H1=>/= /(f_equal (fun x: nat => (x - i.+1)%nat)).
+have np0: forall n, (n = n + 0)%nat by move=>a; rewrite addnC.
+rewrite {2 4}(np0 i.+1) subnDl subnDl.
+have n0: forall n: nat, (n-0 = n)%nat.
+   by move=>a; rewrite (np0 (a-0)%nat); apply subnK.
+by rewrite n0 n0.
+Qed.
+
+Lemma perm_map_bij [T: finType] [f : T -> T] (s: seq T): bijective f -> perm_eq (index_enum T) [seq f i | i <- index_enum T].
+Proof.
+rewrite /index_enum; case: index_enum_key=>/=.
+move=>fbij.
+rewrite /perm_eq -enumT -forallb_tnth; apply /forallP=>i /=.
+inversion fbij.
+rewrite enumT enumP count_map -size_filter (@eq_in_filter _ _ (pred1 (g (tnth
+               (cat_tuple (enum_tuple T) (map_tuple [eta f] (enum_tuple T)))
+               i)))).
+   by rewrite size_filter enumP.
+move=> x _ /=.
+apply/eqP/eqP.
+   by move=>/(f_equal g) <-.
+by move=>->.
+Qed.
+
+Lemma image_mem_pred1 (aT: finType) (rT: eqType) (f: aT -> rT) (x: aT): simpl_of_mem (mem (image_mem f (mem (PredOfSimpl.coerce (pred1 x))))) = pred1 (f x).
+Proof. admit. Admitted.
+
+Lemma caratheodory (A: set (Vector.lmodType E)) x: x \in hull A -> exists (n : nat) (g : 'I_n -> (Vector.lmodType E)) (d : {fdist 'I_n}), (n <= (dimv (@fullv R_fieldType E)).+1)%nat /\ range g `<=` A /\ x = <|>_d g.
+Proof.
+move=>/set_mem [n [g [d [gA ->]]]].
+elim: n g d gA=> [| n IHn] g d gA.
+   by elim (fdistI0_False d).
+case nsgt: (n.+1 <= (dimv (@fullv R_fieldType E)).+1)%nat.
+   by exists n.+1, g, d.
+have: exists mu: 'I_(n.+1) -> R, \sum_(i < n.+1) mu i = 0 /\ \sum_(i < n.+1) (mu i) *: g i = 0 /\ exists i, mu i <> 0.
+   clear IHn.
+   move: nsgt; rewrite ltnNge=>/negP/negP nsgt.
+   case sf: (free (in_tuple [seq (g (lift ord0 i)) - (g ord0) | i <- index_enum (ordinal_finType n) ])).
+      have: basis_of fullv (in_tuple [seq (g (lift ord0 i)) - (g ord0) | i <- index_enum (ordinal_finType n) ]).
+         rewrite basisEfree; apply /andP; split=>//; apply /andP; split.
+            by apply subvf.
+         rewrite size_map size_index_enum /= card_ord.
+         by refine (leq_trans _ nsgt).
+      rewrite in_tupleE basisEdim size_map=>/andP [_ nsge].
+      by move: nsge nsgt; rewrite size_index_enum -pred_Sn card_ord ltnNge=>->.
+      move: sf=>/negP /freeN_combination; rewrite in_tupleE size_map /= size_index_enum card_ord=> [[mu [musum [i mui]]]].
+   exists (fun i => match i with | @Ordinal _ 0 _ => - \sum_i mu i | @Ordinal _ i.+1 ilt => mu (Ordinal (ltnSE ilt)) end).
+   split.
+      rewrite big_ord_recl /= addrC; apply /eqP; rewrite subr_eq0; apply /eqP.
+      apply congr_big=>// [[j jlt]] _.
+      by congr mu; apply val_inj.
+   split.
+      rewrite big_ord_recl /= scaleNr addrC scaler_suml -sumrB -{2}musum.
+      apply congr_big=>// j _.
+      rewrite (nth_map j).
+         2: by rewrite size_index_enum card_ord.
+      rewrite scalerBr; congr add; congr (mu _ *: g (lift ord0 _)).
+         by case: j=>j jlt; apply val_inj.
+      have->: index_enum (ordinal_finType n) = (enum 'I_n) by rewrite enumT.
+      by rewrite nth_ord_enum.
+   by exists (lift ord0 i)=>/=; apply/eqP; rewrite /is_true -{}mui; congr (mu _ != 0); case: i=>[i ilt]; apply val_inj.
+move=>[mu [muR [muE [i mui]]]].
+wlog: mu muR muE mui / mu i > 0.
+   move=> H.
+   case mupos: (0 < mu i).
+      by apply (H mu).
+   apply (H (fun i => - mu i)).
+      + by rewrite sumrN muR oppr0.
+      + by rewrite -{2}oppr0 -{2}muE -sumrN; apply congr_big=>// j _; rewrite scaleNr.
+      + by move=> /(f_equal (@GRing.opp R_zmodType)); rewrite opprK oppr0.
+      + move: mui=>/eqP; rewrite [mu i != 0]real_neqr_lt. move=>/orP; case; [ by rewrite oppr_gt0 | by rewrite mupos ].
+         by apply num_real.
+         by apply num_real.
+move=>/(@Order.TotalTheory.arg_minP _ _ _ i (fun i => 0 < mu i) (fun i => (d i) / (mu i))) [im muip muim]; clear i mui.
+wlog: g d gA mu muR muE im muip muim / (im == ord0)%N.
+   set f := fun i: nat => if i == nat_of_ord im then 0%nat else if i == 0%nat then nat_of_ord im else i.
+   have fcan: cancel f f.
+      move=> j; rewrite /f.
+      case jim: (j == im); case j0: (j == 0%nat); case im0: (0%nat == im); rewrite ?eq_refl; rewrite ?jim ?j0; move: jim j0 im0=>/eqP jim /eqP j0 /eqP im0; try subst j; try subst im =>//; try reflexivity; exact im0.
+   have flt: forall i: 'I_n.+1, (f i < n.+1)%nat by move=>[j jlt]; rewrite /f; case jim: (j == im); case j0: (j == 0%nat).
+   set f' := fun i => Ordinal (flt i).
+   have fcan': cancel f' f' by move=>[j jlt]; apply val_inj, fcan.
+   have fbij: bijective f' by exists f'; move=> [j jlt]; apply fcan'.
+   move=>/(_ (fun i => g (f' i)) (FDistMap.d f' d)).
+   have gA': [set g (f' i) | i in [set: 'I_n.+1]] `<=` A by move=>y [i _ <-]; apply gA; eexists.
+   move=>/(_ gA' (fun i => mu (f' i))).
+   have mu'R: \sum_(i0 < n.+1) mu (f' i0) = 0.
+      rewrite (perm_big _ (perm_map_bij _ fbij)); [| exact nil ].
+      by rewrite big_map -{4}muR; apply congr_big=>// [[j jlt]] _; congr mu; apply fcan'.
+   move=>/(_ mu'R).
+   have mu'E: \sum_(i0 < n.+1) mu (f' i0) *: g (f' i0) = 0.
+      rewrite (perm_big _ (perm_map_bij _ fbij)); [| exact nil ].
+      rewrite big_map -{4}muE; apply congr_big=>// j _.
+      congr (mu _ *: g _); apply fcan'.
+   move=>/(_ mu'E (f' im)).
+   have muip': 0 < mu (f' (f' im)) by refine (eq_ind _ (fun x => 0 < x) muip _ _); congr mu; rewrite fcan'.
+   move=>/(_ muip').
+   have muim': forall j : ordinal_finType n.+1,
+  0 < mu (f' j) ->
+  FDistMap.d f' d (f' im) / mu (f' (f' im)) <= FDistMap.d f' d j / mu (f' j).
+      move=>j /muim.
+      rewrite fcan' FDistMap.dE (big_pred1 im) /=.
+         2: by move: (@pre_image _ _ f' (bij_inj fbij) (pred1 im))=>/funext/=; rewrite image_mem_pred1=>->.
+      rewrite FDistMap.dE (big_pred1 (f' j)) //.
+      by rewrite -{1}[j]fcan'; move: (@pre_image _ _ f' (bij_inj fbij) (pred1 (f' j)))=>/funext/=; rewrite image_mem_pred1=>->.
+   move=>/(_ muim').
+   have im0: f' im == ord0.
+      by apply /eqP; apply val_inj=>/=; rewrite /f; rewrite eq_refl.
+   move=>/(_ im0) [n' [g' [d' [n'le [g'A e]]]]].
+   exists n', g', d'; split=>//; split=>//; rewrite -e.
+   rewrite 2!avgnrE /avgnr.
+   rewrite (perm_big _ (perm_map_bij _ fbij)); [| exact nil ].
+   rewrite big_map; apply congr_big=>// j _.
+   rewrite FDistMap.dE (big_pred1 (f' j))=>// k /=.
+   by rewrite unfold_in=>/=; apply/eqP/eqP=>e'; apply (bij_inj fbij); rewrite fcan'.
+move=>/eqP ime; subst im.
+have leS: forall n m, (n <= m -> n < m.+1)%nat by move=> ? ?; rewrite ltnS.
+have mu0: mu ord0 != 0 by apply /eqP=>mu0; move: muip; rewrite mu0 lt0r eq_refl.
+have k0mu0: d ord0 / mu ord0 * mu ord0 = d ord0 by rewrite -{2}[mu ord0]divr1 mulf_div [_*1]mulrC -mulf_div divr1 mulfV // mulr1.
+set ef: 'I_n -> R := finfun (fun i => d (lift ord0 i) - d ord0 / mu ord0 * mu (lift ord0 i)).
+have ef0: forall i, (0 <= ef i)%R.
+   move=>i; apply /RleP; rewrite /ef ffunE subr_ge0.
+   case mujp: (0 < mu (lift ord0 i)).
+      by rewrite -ler_pdivl_mulr //; apply muim.
+   apply (@le_trans _ _ 0).
+      2: apply/leRP; exact (FDist.ge0 d (lift ord0 i)).
+   apply mulr_ge0_le0.
+      apply divr_ge0.
+         apply/leRP; exact (FDist.ge0 d ord0).
+      by move: muip; rewrite lt0r=>/andP [_ ->].
+   rewrite real_leNgt.
+      by rewrite mujp.
+      by apply num_real.
+   by apply num_real.
+have ef1: (\sum_(a in 'I_n) ef a)%R = 1%R.
+   by rewrite -[1%R]subr0 -(mulr0 (d ord0 / mu ord0)) -(FDist.f1 d) -muR mulr_sumr -sumrB big_ord_recl k0mu0 subrr add0r; apply congr_big=>// i _; rewrite /ef ffunE.
+set e := FDist.make ef0 ef1.
+move: IHn=>/(_ (fun i=> g (lift ord0 i)) e).
+have g'A: [set g (lift ord0 i) | i in [set: 'I_n]] `<=` A by move=>y [i _ <-]; apply gA; eexists.
+move=>/(_ g'A) [n' [g' [d' [n'le [g'A' gde]]]]].
+exists n', g', d'.
+split=>//; split=>//.
+rewrite -gde 2!avgnrE /avgnr big_ord_recl -k0mu0 -scalerA.
+move: muE=>/eqP; rewrite big_ord_recl addr_eq0=>/eqP->.
+rewrite scalerN -scaleNr scaler_sumr -big_split; apply congr_big=>// i _.
+by rewrite scalerA /= -scalerDl; congr scale; rewrite addrC mulNr ffunE.
+Qed.
+End caratheodory.
 Section linear_affine.
 Variable E F: lmodType R.
 Variable f: {linear E -> F}.


### PR DESCRIPTION
Strengthens convA' and convACA' and adds a few lemmas. Defines l-modules as convex spaces.
Proves Carathéodory's Theorem.
Contains general purpose lemmas that should not stay here (e.g. everything in section split_prod and everything in section caratheodory except lemma caratheodory). 