### PR TITLE
make fsdistbindE unconditional; generalize fsdistbindEwiden

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,15 @@
 -------------------
+from 0.5.2 to master
+-------------------
+- renamed
+  + fsdistbindE -> fsdistbindEcond
+- added
+  + fsdistbindE (unconditional RHS)
+  + pmulR_lgt0', pmulR_rgt0'
+- changed
+  + fsdistbindEwiden (generalized)
+
+-------------------
 from 0.5.1 to 0.5.2
 -------------------
 compatibility release

--- a/information_theory/jtypes.v
+++ b/information_theory/jtypes.v
@@ -673,7 +673,7 @@ rewrite /split_tuple /= in_setX; apply/andP; split.
 - apply/imsetP; exists tb' => //.
   apply/val_inj => /=.
   rewrite eq_tcast /=.
-  by rewrite -tb's sum_num_occ_rec take_take // leq_addr.
+  by rewrite -tb's sum_num_occ_rec take_takel// leq_addr.
 - rewrite in_set.
   apply/eqP/val_inj => /=.
   by rewrite eq_tcast -Ha take0.
@@ -691,7 +691,7 @@ symmetry in Htb_2; move/tcast2tval in Htb_2; rewrite /= in Htb_2.
 rewrite /split_tuple /= in_setX.
 apply/andP; split.
 - apply/imsetP; exists tb => //; apply/val_inj => /=.
-  by rewrite eq_tcast /= -Htb_2 sum_num_occ_rec take_take // leq_addr.
+  by rewrite eq_tcast /= -Htb_2 sum_num_occ_rec take_takel // leq_addr.
 - rewrite in_set.
   set t := Tuple _.
   have Ht : tval t = take N(enum_val k | ta) (drop (sum_num_occ ta k) sb) by [].
@@ -704,7 +704,7 @@ apply/andP; split.
   rewrite -Htb_2 in Ht.
   apply/eqP.
   have Ht2 : tval t = drop (sum_num_occ ta k) (take (sum_num_occ ta k.+1) tb).
-    rewrite Ht {1}sum_num_occ_rec take_drop take_take; last by rewrite addnC.
+    rewrite Ht {1}sum_num_occ_rec take_drop take_takel; last by rewrite addnC.
     by rewrite addnC sum_num_occ_rec.
   congr (_ %:R / _%:R)%R.
   exact/esym/num_occ_num_co_occ.

--- a/lib/ssrR.v
+++ b/lib/ssrR.v
@@ -539,6 +539,16 @@ Proof. by move=> Hm; rewrite -!(mulRC m) leR_pmul2l'. Qed.
 Lemma pmulR_lgt0 x y : 0 < x -> (0 < y * x) <-> (0 < y).
 Proof. by move=> x0; rewrite -{1}(mul0R x) ltR_pmul2r. Qed.
 
+Lemma pmulR_lgt0' [x y : R] :  0 < y * x -> 0 <= x -> 0 < y.
+Proof.
+case/boolP: (x == 0) => [/eqP -> |]; first by rewrite mulR0 => /ltRR.
+move=> /eqP /nesym ? /[swap] ? /pmulR_lgt0; apply.
+by rewrite ltR_neqAle; split.
+Qed.
+
+Lemma pmulR_rgt0' [x y : R] :  0 < x * y -> 0 <= x -> 0 < y.
+Proof. by rewrite mulRC; exact: pmulR_lgt0'. Qed.
+
 Arguments leR_pmul2l [_] [_] [_].
 Arguments leR_pmul2r [_] [_] [_].
 Arguments ltR_pmul2l [_] [_] [_].

--- a/probability/fsdist.v
+++ b/probability/fsdist.v
@@ -300,7 +300,7 @@ Lemma fsdist1bind (A B : choiceType) (a : A) (f : A -> {dist B}) :
   fsdist1 a >>= f = f a.
 Proof.
 apply/val_inj/val_inj => /=; congr fmap_of_fsfun; apply/fsfunP => b.
-by rewrite fsdistbindE supp_fsdist1 big_seq_fset1 fsdist1E inE eqxx mul1R.
+by rewrite fsdistbindE supp_fsdist1 big_seq_fset1 fsdist1xx mul1R.
 Qed.
 
 Lemma fsdistbind1 (A : choiceType) (p : {dist A}) : p >>= (@fsdist1 A) = p.

--- a/probability/fsdist.v
+++ b/probability/fsdist.v
@@ -252,19 +252,16 @@ Lemma fsdistbindEcond x :
   fsdistbind x = if x \in D then \sum_(a <- finsupp p) p a * (g a) x else 0.
 Proof. by rewrite /fsdistbind; unlock; rewrite fsfunE. Qed.
 
-Lemma fsdistbindE x :
-  fsdistbind x = \sum_(a <- finsupp p) p a * (g a) x.
+Lemma fsdistbindE x : fsdistbind x = \sum_(a <- finsupp p) p a * (g a) x.
 Proof.
 rewrite fsdistbindEcond.
 case: ifPn => // aD.
 apply/eqP; move: aD; apply: contraLR.
-rewrite eq_sym negbK sumR_neq0; last first.
-  by move=> ?; exact: mulR_ge0.
+rewrite eq_sym negbK sumR_neq0; last by move=> ?; exact: mulR_ge0.
 case => i [] suppi pg0.
 apply/bigfcupP; exists (g i).
-  by rewrite in_imfset.
-rewrite mem_finsupp.
-by apply/gtR_eqF/(pmulR_rgt0' pg0).
+- by rewrite in_imfset.
+- by rewrite mem_finsupp; apply/gtR_eqF/(pmulR_rgt0' pg0).
 Qed.
 
 Lemma fsdistbindEwiden S x :
@@ -303,7 +300,7 @@ apply/val_inj/val_inj => /=; congr fmap_of_fsfun; apply/fsfunP => b.
 by rewrite fsdistbindE supp_fsdist1 big_seq_fset1 fsdist1xx mul1R.
 Qed.
 
-Lemma fsdistbind1 (A : choiceType) (p : {dist A}) : p >>= (@fsdist1 A) = p.
+Lemma fsdistbind1 (A : choiceType) (p : {dist A}) : p >>= @fsdist1 A = p.
 Proof.
 apply/val_inj/val_inj => /=; congr fmap_of_fsfun; apply/fsfunP => b.
 rewrite fsdistbindEcond; case: ifPn => [|H].
@@ -352,8 +349,7 @@ Qed.
 Definition fsdistmapE (A B : choiceType) (f : A -> B) (d : {dist A}) b :
   fsdistmap f d b = \sum_(a <- finsupp d | f a == b) d a.
 Proof.
-rewrite {1}/fsdistmap [in LHS]fsdistbindE.
-rewrite (bigID (fun a => f a == b)) /=.
+rewrite {1}/fsdistmap [in LHS]fsdistbindE (bigID (fun a => f a == b)) /=.
 rewrite [X in (_ + X)%R = _](_ : _ = 0) ?addR0; last first.
   by rewrite big1 // => a fab; rewrite fsdist10 ?mulR0// eq_sym.
 by apply eq_bigr => a /eqP ->; rewrite fsdist1xx mulR1.


### PR DESCRIPTION
This PR
1.  simplifies fsdistbindE and proofs using it.
2. generalizes fsdistbindEwiden.

The original fsdistbindE is preserved as fsdistbindEcond, whish is necessary in some proofs:
Lemma fsdistbindEcond x :
  fsdistbind x = if x \in D then \sum_(a <- finsupp p) p a * (g a) x else 0.

Simplified version has no conditional on the RHS and easier to use in most cases:
Lemma fsdistbindE x :
  fsdistbind x = \sum_(a <- finsupp p) p a * (g a) x.

fsdistbindEwiden is generalized to arbitrary set inclusions rather than
finsupp a <= finsupp (a <|p|> b)
