### PR TITLE
define fsdist_conv using the convType of R

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,8 +6,13 @@ from 0.5.2 to master
 - added
   + fsdistbindE (unconditional RHS)
   + pmulR_lgt0', pmulR_rgt0'
+  + supp_fsdist_convn
 - changed
   + fsdistbindEwiden (generalized)
+  + fsdist_convE, fsdist_convnE (RHS slightly changed)
+- removed
+  + fsdist_convn (use Convn)
+  + fsdist_convA (use convA0)
 
 -------------------
 from 0.5.1 to 0.5.2

--- a/probability/convex.v
+++ b/probability/convex.v
@@ -568,7 +568,7 @@ HB.mixin Record isRealCone (A : Type) of isQuasiRealCone A := {
     @scalept [the quasiRealCone of A] (p + q)%coqR x = addpt (scalept p x) (scalept q x) }.
 
 #[short(type=realCone)]
-HB.structure Definition RealCone := { A of isQuasiRealCone A & isRealCone A}.
+HB.structure Definition RealCone := { A of isQuasiRealCone A & isRealCone A }.
 
 Section real_cone_theory.
 Variable A : realCone.

--- a/probability/convex.v
+++ b/probability/convex.v
@@ -6,8 +6,8 @@ From mathcomp Require Import mathcomp_extra boolp classical_sets Rstruct.
 From mathcomp Require Import ssrnum ereal.
 From mathcomp Require Import lra Rstruct reals.
 Require Import Reals.
-Require Import ssrR Rstruct_ext Reals_ext Ranalysis_ext ssr_ext ssralg_ext logb Rbigop.
-Require Import realType_ext fdist.
+Require Import ssrR Rstruct_ext Reals_ext Ranalysis_ext ssr_ext ssralg_ext logb.
+Require Import Rbigop realType_ext fdist.
 From mathcomp Require vector.
 
 Undelimit Scope R_scope.

--- a/probability/fsdist.v
+++ b/probability/fsdist.v
@@ -699,15 +699,6 @@ Implicit Types (p : {prob real_realType}) (a b c : {dist A}).
 Local Open Scope reals_ext_scope.
 Local Open Scope convex_scope.
 
-(* looks like to be only used in monae/proba_monad_model.v;
-   should either be removed (preferably also changing the ProbaMonad interface),
-   or have the name changed to fsdist_convA0 *)
-(* TODO: rm duplicated *)
-Definition fsdist_convA (p q r s : {prob real_realType}) (mx my mz : {dist A}) :
-  p = r * s :> R /\ (Prob.p s).~ = (Prob.p p).~ * (Prob.p q).~ ->
-  mx <| p |> (my <| q |> mz) = (mx <| r |> my) <| s |> mz.
-Proof. by case=> ? ? ; exact: convA0. Qed.
-
 Lemma finsupp_conv_subr a b p :
   p != 0%:pr -> finsupp a `<=` finsupp (a <|p|> b).
 Proof.


### PR DESCRIPTION
The convex space structure on fsdist has been provided first by defining fsdist_convn and then
fsdist_conv using it, introducing many complications in the proofs of basic lemmas.

This PR corrects it, defining the binary fsdist_conv using the convex structure on R, and using
the generic Convn instead of defining fsdist_convn.

NB:
- fsdist_convA is removed; this is used in proba_monad_model.v in monae
- fsdist_convE is changed; this probably affects its use in altprob_model.v in monae