### PR TITLE
Generalize operations of random variables and add bij_RV_unif, etc.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,19 @@
+
+* changed:
+- renamed
+  + neg_RV -> opp_RV
+	+ trans_min_RV -> trans_sub_RV
+	+ seq.seq -> seq
+- in probability/proba.v
+  + split operations into sections according to their types of values:
+    random_variables, zmod_random_variables, ring_random_variables,
+    and real_random_variables
+  + notation "X '`/' n" is changed from (1 / n%:R) to (n%:R^-1)
+
+* added
+- in probability/proba.v
+  + lemma bij_RV_unif, bij_comp_RV, neg_RV_unif, trans_RV_unif
+
 -------------------
 from 0.7.7 to 0.9.0
 -------------------

--- a/information_theory/aep.v
+++ b/information_theory/aep.v
@@ -50,7 +50,7 @@ transitivity
     (\sum_(a in A) ((- log (P a))^+2 * P a - 2 * `H P * - log (P a) * P a +
                     `H P ^+ 2 * P a))%R.
   apply eq_bigr => a _.
-  rewrite /scalel_RV /log_RV /neg_RV /trans_add_RV /sq_RV /comp_RV /= /sub_RV.
+  rewrite /scalel_RV /log_RV /opp_RV /trans_add_RV /sq_RV /comp_RV /= /sub_RV.
   by rewrite /ambient_dist -!mulrBl -mulrDl.
 rewrite big_split /= big_split /= -big_distrr /= (FDist.f1 P) mulr1.
 rewrite (_ : \sum_(a in A) - _ = - (2 * `H P ^+ 2))%R; last first.
@@ -144,7 +144,7 @@ have H2 k i : `V ((\row_(i < k.+1) `-- (`log P)) ``_ i) = aep_sigma2 P.
 have {H1 H2} := (wlln (H1 n) (H2 n) Hsum Hepsilon).
 move/(le_trans _); apply.
 apply/subset_Pr/subsetP => ta; rewrite 2!inE => /andP[H1].
-rewrite /sum_mlog_prod [`-- (`log _)]lock /= -lock /scalel_RV /log_RV /neg_RV/=.
+rewrite /sum_mlog_prod [`-- (`log _)]lock /= -lock /scalel_RV /log_RV /opp_RV/=.
 rewrite fdist_rVE log_prodr_sumr_mlog //.
 apply/prod_gt0_inv.
   by move=> x; exact: FDist.ge0.

--- a/information_theory/entropy.v
+++ b/information_theory/entropy.v
@@ -208,7 +208,7 @@ Variables (U A B : finType) (P : R.-fdist U) (X : {RV P -> A}) (Y : {RV P -> B})
 
 (* 2.9 *)
 Lemma eqn29 : `H(X, Y) = - `E (`log `p_[% X, Y]).
-Proof. by rewrite /joint_entropy_RV joint_entropyE E_neg_RV. Qed.
+Proof. by rewrite /joint_entropy_RV joint_entropyE E_opp_RV. Qed.
 
 End joint_entropy_RV_prop.
 

--- a/information_theory/typ_seq.v
+++ b/information_theory/typ_seq.v
@@ -184,7 +184,7 @@ have -> : Pr (P `^ n.+1)%fdist (~: p) =
   by rewrite !inE /= => /eqP Hi; rewrite negb_and Hi ltxx.
 rewrite {1}/Pr big1 ?add0r; last by move=> /= v; rewrite inE => /eqP.
 apply/(le_trans _ (aep He k0_k))/subset_Pr/subsetP => /= t.
-rewrite !inE /= => /andP[-> H3].
+rewrite mul1r !inE /= => /andP[-> H3].
 by rewrite /log_RV /= /scalel_RV /= mulrN -mulNr ltW.
 Qed.
 

--- a/information_theory/typ_seq.v
+++ b/information_theory/typ_seq.v
@@ -184,7 +184,7 @@ have -> : Pr (P `^ n.+1)%fdist (~: p) =
   by rewrite !inE /= => /eqP Hi; rewrite negb_and Hi ltxx.
 rewrite {1}/Pr big1 ?add0r; last by move=> /= v; rewrite inE => /eqP.
 apply/(le_trans _ (aep He k0_k))/subset_Pr/subsetP => /= t.
-rewrite mul1r !inE /= => /andP[-> H3].
+rewrite !inE /= => /andP[-> H3].
 by rewrite /log_RV /= /scalel_RV /= mulrN -mulNr ltW.
 Qed.
 

--- a/probability/proba.v
+++ b/probability/proba.v
@@ -649,7 +649,7 @@ Section ring_random_variables.
 Context {R : realType}.
 Local Open Scope ring_scope.
 
-Variables (U : finType)(P : R.-fdist U)(V : ringType).
+Variables (U : finType) (P : R.-fdist U) (V : ringType).
 
 Definition scalel_RV k (X : {RV P -> V}) : {RV P -> V} := fun x => k * X x.
 Definition scaler_RV (X : {RV P -> V}) k : {RV P -> V} := fun x => X x * k.

--- a/probability/proba.v
+++ b/probability/proba.v
@@ -613,7 +613,7 @@ Section zmod_random_variables.
 Context {R : realType}.
 Local Open Scope ring_scope.
 
-Variables (U : finType)(P : R.-fdist U)(V : zmodType).
+Variables (U : finType) (P : R.-fdist U) (V : zmodType).
 
 Definition add_RV (X Y : {RV P -> V}) : {RV P -> V} := fun x => X x + Y x.
 Definition sub_RV (X Y : {RV P -> V}) : {RV P -> V} := fun x => X x - Y x.

--- a/probability/proba.v
+++ b/probability/proba.v
@@ -611,9 +611,8 @@ Notation "f `o X" := (comp_RV f X).
 
 Section zmod_random_variables.
 Context {R : realType}.
-Local Open Scope ring_scope.
-
 Variables (U : finType) (P : R.-fdist U) (V : zmodType).
+Local Open Scope ring_scope.
 
 Definition add_RV (X Y : {RV P -> V}) : {RV P -> V} := fun x => X x + Y x.
 Definition sub_RV (X Y : {RV P -> V}) : {RV P -> V} := fun x => X x - Y x.

--- a/probability/proba.v
+++ b/probability/proba.v
@@ -617,19 +617,17 @@ Local Open Scope ring_scope.
 Definition add_RV (X Y : {RV P -> V}) : {RV P -> V} := fun x => X x + Y x.
 Definition sub_RV (X Y : {RV P -> V}) : {RV P -> V} := fun x => X x - Y x.
 
-(* TODO: neg to opp *)
-Definition neg_RV (X : {RV P -> V}) : {RV P -> V} := fun x => - X x.
+Definition opp_RV (X : {RV P -> V}) : {RV P -> V} := fun x => - X x.
 Definition trans_add_RV (X : {RV P -> V}) m : {RV P -> V} := fun x => X x + m.
-(* TODO: min to sub; no longer necessary *)
-Definition trans_min_RV (X : {RV P -> V}) m : {RV P -> V} := fun x => X x - m.
-Definition sumR_RV I (r : seq.seq I) (p : pred I) (X : I -> {RV P -> V}) : {RV P -> V} :=
+Definition trans_sub_RV (X : {RV P -> V}) m : {RV P -> V} := fun x => X x - m.
+Definition sumR_RV I (r : seq I) (p : pred I) (X : I -> {RV P -> V}) : {RV P -> V} :=
   fun x => \sum_(i <- r | p i) X i x.
 
 Local Notation "X `+ Y" := (add_RV X Y) : proba_scope.
 Local Notation "X `- Y" := (sub_RV X Y) : proba_scope.
 
 Lemma sub_RV_neg (X Y : {RV P -> V}) :
-  X `- Y = X `+ neg_RV Y.
+  X `- Y = X `+ opp_RV Y.
 Proof. by []. Qed.
 
 End zmod_random_variables.
@@ -637,12 +635,8 @@ End zmod_random_variables.
 Notation "X `+ Y" := (add_RV X Y) : proba_scope.
 Notation "X `- Y" := (sub_RV X Y) : proba_scope.
 Notation "X '`+cst' m" := (trans_add_RV X m) : proba_scope.
-Notation "X '`-cst' m" := (trans_min_RV X m) : proba_scope.
-Notation "'`--' P" := (neg_RV P) : proba_scope.
-
-Section zmod_random_variables_lemmas.
-
-End zmod_random_variables_lemmas.
+Notation "X '`-cst' m" := (trans_sub_RV X m) : proba_scope.
+Notation "'`--' P" := (opp_RV P) : proba_scope.
 
 Section ring_random_variables.
 Local Open Scope ring_scope.
@@ -657,7 +651,7 @@ End ring_random_variables.
 
 Notation "k `cst* X" := (scalel_RV k X) : proba_scope.
 Notation "X `*cst k" := (scaler_RV X k) : proba_scope.
-Notation "X '`/' n" := (scalel_RV (1 / n%:R) X) : proba_scope.
+Notation "X '`/' n" := (scalel_RV n%:R^-1 X) : proba_scope.
 Notation "X '`^2' " := (sq_RV X) : proba_scope.
 
 Section real_random_variables.
@@ -907,7 +901,7 @@ Section expected_value_prop.
 Context {R : realType}.
 Variables (U : finType) (P : R.-fdist U) (X Y : {RV P -> R}).
 
-Lemma E_neg_RV : `E (`-- X) = - `E X.
+Lemma E_opp_RV : `E (`-- X) = - `E X.
 Proof.
 by rewrite /Ex/= big_morph_oppr/=; apply: eq_bigr => u _; rewrite mulNr.
 Qed.
@@ -951,9 +945,9 @@ transitivity (\sum_(u in U) (X u * P u + m * P u)).
 by rewrite big_split /= -big_distrr /= FDist.f1 mulr1.
 Qed.
 
-Lemma E_trans_min_RV m : `E (X `-cst m) = `E X - m.
+Lemma E_trans_sub_RV m : `E (X `-cst m) = `E X - m.
 Proof.
-rewrite /trans_min_RV /=.
+rewrite /trans_sub_RV /=.
 transitivity (\sum_(u in U) (X u * P u + - m * P u)).
   by apply eq_bigr => u _ /=; rewrite mulrDl.
 by rewrite big_split /= -big_distrr /= FDist.f1 mulr1.
@@ -963,7 +957,7 @@ Lemma E_trans_RV_id_rem m :
   `E ((X `-cst m) `^2) = `E ((X `^2 `- (2 * m `cst* X)) `+cst m ^+ 2).
 Proof.
 apply eq_bigr => a _.
-rewrite /sub_RV /trans_add_RV /trans_min_RV /sq_RV /= /comp_RV /scalel_RV /=.
+rewrite /sub_RV /trans_add_RV /trans_sub_RV /sq_RV /= /comp_RV /scalel_RV /=.
 by rewrite /ambient_dist; lra.
 Qed.
 
@@ -1059,7 +1053,8 @@ Lemma Ind_cap (S1 S2 : {set A}) (x : A) :
   Ind (S1 :&: S2) x = Ind S1 x * Ind S2 x.
 Proof. by rewrite /Ind inE; case: in_mem; case: in_mem=>/=; lra. Qed.
 
-Lemma Ind_bigcap I (e : I -> {set A}) (r : seq.seq I) (p : pred I) x :
+
+Lemma Ind_bigcap I (e : I -> {set A}) (r : seq I) (p : pred I) x :
   Ind (\bigcap_(j <- r | p j) e j) x = \prod_(j <- r | p j) (Ind (e j) x).
 Proof.
 apply (big_ind2 (R1 := {set A}) (R2 := R)); last by [].
@@ -1245,14 +1240,14 @@ rewrite {1}/`V [in X in X = _]/= E_scalel_RV.
 pose Y : {RV P -> R} := k `cst* (X `+cst - `E X).
 rewrite (@E_comp_RV_ext _ _ P ((k `cst* X) `-cst k * `E X) Y) //; last first.
   rewrite boolp.funeqE => /= x.
-  by rewrite /Y /scalel_RV /= /trans_min_RV /trans_add_RV; lra.
+  by rewrite /Y /scalel_RV /= /trans_sub_RV /trans_add_RV; lra.
 by rewrite E_comp_RV ?E_scalel_RV // => *; lra.
 Qed.
 
 Lemma Var_trans m : `V (X `+cst m) = `V X.
 Proof.
 rewrite /Var E_trans_add_RV; congr (`E (_ `^2)).
-by rewrite boolp.funeqE => /= u; rewrite /trans_add_RV /trans_min_RV /=; lra.
+by rewrite boolp.funeqE => /= u; rewrite /trans_add_RV /trans_sub_RV /=; lra.
 Qed.
 
 End variance_prop.
@@ -1421,7 +1416,7 @@ Hypothesis Xunif : `p_X = fdist_uniform card_A.
 Lemma trans_RV_unif (m : A) : `p_(X `+cst m) = fdist_uniform card_A.
 Proof. exact: (bij_RV_unif Xunif (addrK m) (subrK m)). Qed.
 
-Lemma neg_RV_unif : `p_(`-- X) = fdist_uniform card_A.
+Lemma opp_RV_unif : `p_(`-- X) = fdist_uniform card_A.
 Proof. exact: (bij_RV_unif Xunif opprK opprK). Qed.
 
 End uniform_finZmod_RV_lemmas.
@@ -2295,7 +2290,7 @@ Proof.
 move=> s Hs; destruct n; first by inversion sum_Xs.
 rewrite (Var_scale X) // (V_sum_n sum_Xs Hs) //.
 rewrite mulrCA (mulrA _ _ s) -expr2.
-by rewrite mul1r exprVn mulrA mulVf ?mul1r// sqrf_eq0 pnatr_eq0.
+by rewrite exprVn mulrA mulVf ?mul1r// sqrf_eq0 pnatr_eq0.
 Qed.
 
 End sum_n_rand_var.
@@ -2327,7 +2322,7 @@ have <- : `V (X `/ n.+1) = sigma2 / n.+1%:R.
   by rewrite [RHS]mulrC (mulrA _ n.+1%:R) mulVf ?pnatr_eq0// !mul1r.
 have <- : `E (X `/ n.+1) = miu.
   rewrite E_scalel_RV (E_sum_n X_Xs).
-  rewrite !mul1r mulrC eqr_divr_mulr ?pnatr_eq0// (eq_bigr (fun=> miu)) //.
+  rewrite mulrC eqr_divr_mulr ?pnatr_eq0// (eq_bigr (fun=> miu)) //.
   by rewrite big_const /= iter_addr cardE /= size_enum_ord addr0 mulr_natr.
 move/le_trans: (chebyshev_inequality (X `/ n.+1) e0); apply.
 by rewrite lexx.

--- a/probability/proba.v
+++ b/probability/proba.v
@@ -645,9 +645,8 @@ Section zmod_random_variables_lemmas.
 End zmod_random_variables_lemmas.
 
 Section ring_random_variables.
-Context {R : realType}.
 Local Open Scope ring_scope.
-
+Context {R : realType}.
 Variables (U : finType) (P : R.-fdist U) (V : ringType).
 
 Definition scalel_RV k (X : {RV P -> V}) : {RV P -> V} := fun x => k * X x.

--- a/probability/proba.v
+++ b/probability/proba.v
@@ -664,8 +664,7 @@ Notation "X '`^2' " := (sq_RV X) : proba_scope.
 
 Section real_random_variables.
 Context {R : realType}.
-
-Variables (U : finType)(P : R.-fdist U).
+Variables (U : finType) (P : R.-fdist U).
 
 Definition log_RV : {RV P -> R} := fun x => log (P x).
 

--- a/probability/proba.v
+++ b/probability/proba.v
@@ -629,7 +629,7 @@ Definition sumR_RV I (r : seq.seq I) (p : pred I) (X : I -> {RV P -> V}) : {RV P
 Local Notation "X `+ Y" := (add_RV X Y) : proba_scope.
 Local Notation "X `- Y" := (sub_RV X Y) : proba_scope.
 
-Lemma sub_RV_neg  (X Y : {RV P -> V}):
+Lemma sub_RV_neg  (X Y : {RV P -> V}) :
   X `- Y = X `+ neg_RV Y.
 Proof. by []. Qed.
 

--- a/probability/proba.v
+++ b/probability/proba.v
@@ -1410,7 +1410,7 @@ End uniform_finType_RV_lemmas.
 Section uniform_finZmod_RV_lemmas.
 Local Open Scope proba_scope.
 Context {R : realType}.
-Variables (T: finType) (P : R.-fdist T) (A : finZmodType).
+Variables (T : finType) (P : R.-fdist T) (A : finZmodType).
 Variable X : {RV P -> A}.
 
 Let n := #|A|.-1.

--- a/probability/proba.v
+++ b/probability/proba.v
@@ -1384,7 +1384,7 @@ End mutual_independence.
 Section uniform_finType_RV_lemmas.
 Local Open Scope proba_scope.
 Context {R : realType}.
-Variables (T: finType) (n: nat) (P : R.-fdist T) (A : finType).
+Variables (T : finType) (n : nat) (P : R.-fdist T) (A : finType).
 Variable X : {RV P -> A}.
 
 Hypothesis card_A : #|A| = n.+1.

--- a/probability/proba.v
+++ b/probability/proba.v
@@ -1424,6 +1424,7 @@ Proof. exact: (bij_RV_unif Xunif (addrK m) (subrK m)). Qed.
 
 Lemma neg_RV_unif : `p_(`-- X) = fdist_uniform card_A.
 Proof. exact: (bij_RV_unif Xunif opprK opprK). Qed.
+
 End uniform_finZmod_RV_lemmas.
 
 Section conditional_probablity.

--- a/probability/proba.v
+++ b/probability/proba.v
@@ -629,7 +629,7 @@ Definition sumR_RV I (r : seq.seq I) (p : pred I) (X : I -> {RV P -> V}) : {RV P
 Local Notation "X `+ Y" := (add_RV X Y) : proba_scope.
 Local Notation "X `- Y" := (sub_RV X Y) : proba_scope.
 
-Lemma sub_RV_neg  (X Y : {RV P -> V}) :
+Lemma sub_RV_neg (X Y : {RV P -> V}) :
   X `- Y = X `+ neg_RV Y.
 Proof. by []. Qed.
 

--- a/robust/robustmean.v
+++ b/robust/robustmean.v
@@ -46,9 +46,9 @@ Lemma mul_RVCA : left_commutative mul_RV.
 Proof. by move=> *; apply: boolp.funext=> u /=; rewrite mulrCA. Qed.
 Lemma mul_RVACA : interchange mul_RV mul_RV.
 Proof. by move=> *; apply: boolp.funext=> u /=; rewrite mulrACA. Qed.
-Lemma mul_RVDr : right_distributive mul_RV (@add_RV _ U P).
+Lemma mul_RVDr : right_distributive mul_RV (@add_RV _ U P R).
 Proof. by move=> *; apply: boolp.funext=> u /=; rewrite mulrDr. Qed.
-Lemma mul_RVDl : left_distributive mul_RV (@add_RV _ U P).
+Lemma mul_RVDl : left_distributive mul_RV (@add_RV _ U P R).
 Proof. by move=> *; apply: boolp.funext=> u /=; rewrite mulrDl. Qed.
 Lemma mul_RVBr (f g h : {RV (P) -> (R)}) : f `* (g `- h) = f `* g `- f `* h.
 Proof. by apply: boolp.funext=> u /=; rewrite mulrBr. Qed.
@@ -62,15 +62,15 @@ Section add_RV.
 Context {R : realType}.
 Variables (U : finType) (P : R.-fdist U).
 Arguments add_RV /.
-Lemma add_RVA : associative (@add_RV _ U P).
+Lemma add_RVA : associative (@add_RV _ U P R).
 Proof. by move=> *; apply: boolp.funext=> u /=; rewrite addrA. Qed.
-Lemma add_RVC : commutative (@add_RV _ U P).
+Lemma add_RVC : commutative (@add_RV _ U P R).
 Proof. by move=> *; apply: boolp.funext=> u /=; rewrite addrC. Qed.
-Lemma add_RVAC : right_commutative (@add_RV _ U P).
+Lemma add_RVAC : right_commutative (@add_RV _ U P R).
 Proof. by move=> *; apply: boolp.funext=> u /=; rewrite addrAC. Qed.
-Lemma add_RVCA : left_commutative (@add_RV _ U P).
+Lemma add_RVCA : left_commutative (@add_RV _ U P R).
 Proof. by move=> *; apply: boolp.funext=> u /=; rewrite addrCA. Qed.
-Lemma add_RVACA : interchange (@add_RV _ U P) (@add_RV _ U P).
+Lemma add_RVACA : interchange (@add_RV _ U P R) (@add_RV _ U P R).
 Proof. by move=> *; apply: boolp.funext=> u /=; rewrite addrACA. Qed.
 End add_RV.
 
@@ -104,7 +104,7 @@ Variables (U : finType) (P : R.-fdist U).
 (* Lemma sub_RV_subr (X Y : {RV P -> R}) : X `- Y = (X - Y)%mcR. *)
 (* Proof. reflexivity. Qed. *)
 
-(* Lemma trans_min_RV_subr (X : {RV P -> R}) (y : R) : *)
+(* Lemma trans_sub_RV_subr (X : {RV P -> R}) (y : R) : *)
 (*   X `-cst y = (X - cst y)%ring. *)
 (* Proof. reflexivity. Qed. *)
 Definition fdist_supp_choice : U.
@@ -122,7 +122,7 @@ Defined.
 (* Proof. by rewrite /sq_RV/comp_RV; apply boolp.funext => u /=; rewrite mulR1. Qed. *)
 
 (* Definition RV_ringE := *)
-(*   (add_RV_addr, sub_RV_subr, trans_min_RV_subr, mul_RV_mulr, sq_RV_sqrr). *)
+(*   (add_RV_addr, sub_RV_subr, trans_sub_RV_subr, mul_RV_mulr, sq_RV_sqrr). *)
 End RV_ring.
 
 Section sets_functions.
@@ -306,12 +306,12 @@ Proof. by rewrite [LHS]I_square sq_RVE. Qed.
 Lemma I_mult_one F : (Ind (A:=U) F : {RV P -> R}) `* 1 = Ind (A:=U) F.
 (F: {RV P -> R}): (Ind (A:=U) F: {RV P -> R}) `* 1 = (Ind (A:=U) F : {RV P -> R}). *)
 
-Lemma cEx_trans_min_RV (X : {RV P -> R}) m F : Pr P F != 0 ->
+Lemma cEx_trans_sub_RV (X : {RV P -> R}) m F : Pr P F != 0 ->
   `E_[ (X `-cst m) | F] = `E_[ X | F ] - m.
 Proof.
 move=> PF0.
 rewrite !cExE.
-under eq_bigr do rewrite /trans_min_RV mulrDl.
+under eq_bigr do rewrite /trans_sub_RV mulrDl.
 rewrite big_split/= mulrDl; congr (_ + _).
 by rewrite -big_distrr /= -mulrA divff // mulr1.
 Qed.
@@ -324,7 +324,7 @@ Lemma cEx_sub (X : {RV P -> R}) (F G: {set U}) :
 Proof.
 move=> PrPF_gt0 FsubG.
 rewrite -[X in _ / X]ger0_norm ?ltW // -normf_div.
-by rewrite -cEx_ExInd cEx_trans_min_RV // lt0r_neq0 // PrPF_gt0.
+by rewrite -cEx_ExInd cEx_trans_sub_RV // lt0r_neq0 // PrPF_gt0.
 Qed.
 
 Lemma Ex_cExT (X : {RV P -> R}) : `E X = `E_[X | [set: U]].
@@ -518,7 +518,7 @@ Lemma cEx_trans_RV_id_rem (X: {RV P -> R}) m F:
   `E_[(X `-cst m) `^2 | F] = `E_[((X `^2 `- ((2 * m)%mcR `cst* X)) `+cst m ^+ 2) | F].
 Proof.
 rewrite !cEx_ExInd; congr (_ * _); apply: eq_bigr => a _.
-rewrite /sub_RV /trans_add_RV /trans_min_RV /sq_RV /= /comp_RV /scalel_RV /=.
+rewrite /sub_RV /trans_add_RV /trans_sub_RV /sq_RV /= /comp_RV /scalel_RV /=.
 lra.
 Qed.
 


### PR DESCRIPTION
1. Generalize operations of random variables and add trans_RV_unif and neg_RV_unif
2. Add bij_RV_unif
3. Fix errors: 1^-1 before this change becomes 1/n (need mul1r)