### PR TITLE
Backport centropy_RV_comp_removal from Iwamoto2024; add its dependent lemmas

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,16 @@
 * changed:
 - fdist_gt0, fdist_lt1 (from Prop to bool)
 
+* added
+- in probability/proba.v
+  + pr_comp_removal
+
+- probability/jfdist_cond.v
+  + jPr_comp_eq1
+
+- in information_theory/entropy.v
+  + centropy1_RV_comp0, centropy_RV_comp0, centropy_RV_comp_removal
+
 -------------------
 from 0.9.2 to 0.9.3
 -------------------

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,13 +3,13 @@
 
 * added
 - in probability/proba.v
-  + pr_comp_removal
+  + pr_RV2_comp
 
 - probability/jfdist_cond.v
   + jPr_comp_eq1
 
 - in information_theory/entropy.v
-  + centropy1_RV_comp0, centropy_RV_comp0, centropy_RV_comp_removal
+  + centropy1_RV_comp0, centropy_RV_comp0, joint_entropy_RV_comp
 
 -------------------
 from 0.9.2 to 0.9.3

--- a/information_theory/entropy.v
+++ b/information_theory/entropy.v
@@ -712,7 +712,7 @@ Qed.
 
 End conditional_entropy_prop3.
 
-Section conditional_entropy_RV_comp_removal.
+Section joint_entropy_RV_comp.
 Context {R : realType}.
 Variables (U A B: finType) (f : A -> B).
 Variables (P : R.-fdist U).
@@ -720,16 +720,11 @@ Variables (X : {RV P -> A}) (Y : {RV P -> B}).
 
 Hypothesis HY : Y = f `o X.
 
-Lemma centropy_RV_comp_removal :
+Lemma joint_entropy_RV_comp :
   `H(X, Y) = `H `p_X.
-Proof.
-rewrite chain_rule_RV.
-rewrite HY.
-rewrite centropy_RV_comp0.
-by rewrite addr0.
-Qed.
+Proof. by rewrite chain_rule_RV HY centropy_RV_comp0 addr0. Qed.
 
-End conditional_entropy_RV_comp_removal.
+End joint_entropy_RV_comp.
 
 Section mutual_information.
 Local Open Scope divergence_scope.

--- a/information_theory/entropy.v
+++ b/information_theory/entropy.v
@@ -403,39 +403,32 @@ Qed.
 End centropy1_RV_prop.
 
 Section conditional_entropy1_RV_comp0.
-Context {R : realType} {U A B C: finType} {P : R.-fdist U}.
-Variables (X : {RV P -> A}) (Y : {RV P -> B}).
-Variables (y : B) (f : B -> C).
-Let Z := f `o Y.
+Context {R : realType} {U A B : finType} {P : R.-fdist U}.
+Variables (X : {RV P -> A}) (x : A).
 
-Hypothesis pr_Y_neq0 : `Pr[ Y = y ] != 0.
+Hypothesis pr_X_neq0 : `Pr[ X = x ] != 0.
 
-Lemma centropy1_RV_comp0 :
-  `H[Z | Y = y ] = 0.
+Lemma centropy1_RV_comp0 (f : A -> B) : `H[f `o X | X = x ] = 0.
 Proof.
-rewrite /centropy1_RV /centropy1 big1 ?oppr0 // => z _.
-have [<-|Hfy_neq_z] := eqVneq (f y) z.
+rewrite /centropy1_RV /centropy1 big1 ?oppr0 // => b _.
+have [<-|fxb] := eqVneq (f x) b.
   by rewrite jPr_comp_eq1 // log1 mulr0.
-rewrite jPr_Pr cpr_in1 /Z.
-apply/eqP.
+rewrite jPr_Pr cpr_in1; apply/eqP.
 rewrite [X in X * _]cpr_eqE [X in X / _ * _]pr_eq0 ?mul0r//.
-apply: contra Hfy_neq_z.
+apply: contra fxb.
 by rewrite fin_img_imset/= => /imsetP[t _ [/= -> ->]].
 Qed.
 
 End conditional_entropy1_RV_comp0.
 
 Section conditional_entropy_RV_comp0.
-Context {R : realType} {U A B C: finType} {P : R.-fdist U}.
-Variables (X : {RV P -> A}) (Y : {RV P -> B}).
-Variables (y : B) (f : B -> C).
-Let Z := f `o Y.
+Context {R : realType} {U A B : finType} {P : R.-fdist U}.
+Variables (X : {RV P -> A}).
 
-Lemma centropy_RV_comp0 :
-  `H( Z | Y ) = 0.
+Lemma centropy_RV_comp0 (f : A -> B) : `H( f `o X | X ) = 0.
 Proof.
-rewrite centropy_RVE' big1 // => y' _.
-have [->|Hy_eq0] := eqVneq `Pr[ Y = y' ] 0; first by rewrite mul0r.
+rewrite centropy_RVE' big1 // => a _.
+have [->|Hy_eq0] := eqVneq `Pr[ X = a ] 0; first by rewrite mul0r.
 by rewrite centropy1_RV_comp0 // mulr0.
 Qed.
 
@@ -713,16 +706,11 @@ Qed.
 End conditional_entropy_prop3.
 
 Section joint_entropy_RV_comp.
-Context {R : realType}.
-Variables (U A B: finType) (f : A -> B).
-Variables (P : R.-fdist U).
-Variables (X : {RV P -> A}) (Y : {RV P -> B}).
+Context {R : realType} (U A B : finType) (P : R.-fdist U).
+Variables (X : {RV P -> A}).
 
-Hypothesis HY : Y = f `o X.
-
-Lemma joint_entropy_RV_comp :
-  `H(X, Y) = `H `p_X.
-Proof. by rewrite chain_rule_RV HY centropy_RV_comp0 addr0. Qed.
+Lemma joint_entropy_RV_comp (f : A -> B) : `H(X, f `o X) = `H `p_X.
+Proof. by rewrite chain_rule_RV centropy_RV_comp0 addr0. Qed.
 
 End joint_entropy_RV_comp.
 

--- a/information_theory/entropy.v
+++ b/information_theory/entropy.v
@@ -402,6 +402,45 @@ Qed.
 
 End centropy1_RV_prop.
 
+Section conditional_entropy1_RV_comp0.
+Context {R : realType} {U A B C: finType} {P : R.-fdist U}.
+Variables (X : {RV P -> A}) (Y : {RV P -> B}).
+Variables (y : B) (f : B -> C).
+Let Z := f `o Y.
+
+Hypothesis pr_Y_neq0 : `Pr[ Y = y ] != 0.
+
+Lemma centropy1_RV_comp0 :
+  `H[Z | Y = y ] = 0.
+Proof.
+rewrite /centropy1_RV /centropy1 big1 ?oppr0 // => z _.
+have [<-|Hfy_neq_z] := eqVneq (f y) z.
+  by rewrite jPr_comp_eq1 // log1 mulr0.
+rewrite jPr_Pr cpr_in1 /Z.
+apply/eqP.
+rewrite [X in X * _]cpr_eqE [X in X / _ * _]pr_eq0 ?mul0r//.
+apply: contra Hfy_neq_z.
+by rewrite fin_img_imset/= => /imsetP[t _ [/= -> ->]].
+Qed.
+
+End conditional_entropy1_RV_comp0.
+
+Section conditional_entropy_RV_comp0.
+Context {R : realType} {U A B C: finType} {P : R.-fdist U}.
+Variables (X : {RV P -> A}) (Y : {RV P -> B}).
+Variables (y : B) (f : B -> C).
+Let Z := f `o Y.
+
+Lemma centropy_RV_comp0 :
+  `H( Z | Y ) = 0.
+Proof.
+rewrite centropy_RVE' big1 // => y' _.
+have [->|Hy_eq0] := eqVneq `Pr[ Y = y' ] 0; first by rewrite mul0r.
+by rewrite centropy1_RV_comp0 // mulr0.
+Qed.
+
+End conditional_entropy_RV_comp0.
+
 Section conditional_entropy_prop.
 Variables (R : realType) (A B C : finType) (PQR : R.-fdist (A * B * C)).
 
@@ -672,6 +711,25 @@ by rewrite joint_entropy_self subrr.
 Qed.
 
 End conditional_entropy_prop3.
+
+Section conditional_entropy_RV_comp_removal.
+Context {R : realType}.
+Variables (U A B: finType) (f : A -> B).
+Variables (P : R.-fdist U).
+Variables (X : {RV P -> A}) (Y : {RV P -> B}).
+
+Hypothesis HY : Y = f `o X.
+
+Lemma centropy_RV_comp_removal :
+  `H(X, Y) = `H `p_X.
+Proof.
+rewrite chain_rule_RV.
+rewrite HY.
+rewrite centropy_RV_comp0.
+by rewrite addr0.
+Qed.
+
+End conditional_entropy_RV_comp_removal.
 
 Section mutual_information.
 Local Open Scope divergence_scope.

--- a/probability/jfdist_cond.v
+++ b/probability/jfdist_cond.v
@@ -398,6 +398,24 @@ rewrite /jcPr setX1 fdistX2 2!Pr_set1 fdistXE fdist_prod1.
 by rewrite fdist_prodE /= mulrAC mulfV ?mul1r //; exact/eqP.
 Qed.
 
+Section jPr_comp_eq1.
+Context {R : realType} {U A B C: finType} {P : R.-fdist U}.
+Variables (X : {RV P -> A}) (Y : {RV P -> B}).
+Variables (y : B) (f : B -> C).
+Let Z := f `o Y.
+
+Hypothesis pr_Y_neq0 : `Pr[ Y = y ] != 0.
+
+Lemma jPr_comp_eq1 :
+  \Pr_`p_ [% Z, Y][[set f y] | [set y]] = 1.
+Proof.
+rewrite jPr_Pr cpr_in1 cpr_eqE.
+rewrite pr_comp_removal //=.
+by rewrite divff.
+Qed.
+
+End jPr_comp_eq1.
+
 Section fdist_split.
 Context {R : realType}.
 Variables (A B : finType).

--- a/probability/jfdist_cond.v
+++ b/probability/jfdist_cond.v
@@ -399,20 +399,14 @@ by rewrite fdist_prodE /= mulrAC mulfV ?mul1r //; exact/eqP.
 Qed.
 
 Section jPr_comp_eq1.
-Context {R : realType} {U A B C: finType} {P : R.-fdist U}.
-Variables (X : {RV P -> A}) (Y : {RV P -> B}).
-Variables (y : B) (f : B -> C).
-Let Z := f `o Y.
+Context {R : realType} {U A B : finType} {P : R.-fdist U}.
+Variables (X : {RV P -> A}) (a : A) .
 
-Hypothesis pr_Y_neq0 : `Pr[ Y = y ] != 0.
+Hypothesis pr_Y_neq0 : `Pr[ X = a ] != 0.
 
-Lemma jPr_comp_eq1 :
-  \Pr_`p_ [% Z, Y][[set f y] | [set y]] = 1.
-Proof.
-rewrite jPr_Pr cpr_in1 cpr_eqE.
-rewrite pr_RV2_comp //=.
-by rewrite divff.
-Qed.
+Lemma jPr_comp_eq1 (f : A -> B) :
+  \Pr_`p_ [% f `o X, X][[set f a] | [set a]] = 1.
+Proof. by rewrite jPr_Pr cpr_in1 cpr_eqE pr_RV2_comp //= divff. Qed.
 
 End jPr_comp_eq1.
 

--- a/probability/jfdist_cond.v
+++ b/probability/jfdist_cond.v
@@ -410,7 +410,7 @@ Lemma jPr_comp_eq1 :
   \Pr_`p_ [% Z, Y][[set f y] | [set y]] = 1.
 Proof.
 rewrite jPr_Pr cpr_in1 cpr_eqE.
-rewrite pr_comp_removal //=.
+rewrite pr_RV2_comp //=.
 by rewrite divff.
 Qed.
 

--- a/probability/proba.v
+++ b/probability/proba.v
@@ -873,21 +873,15 @@ Qed.
 End pr_in_comp'.
 
 Section pr_RV2_comp.
-Context {R : realType}.
-Variables (T TX TY TZ : finType).
-Variable P : R.-fdist T.
-Variables (X : {RV P -> TX}) (Y : {RV P -> TY}) (f : TY -> TZ).
-Variables (y : TY) (z : TZ).
-Let Z := f `o Y.
+Context {R : realType} (T A B : finType) (P : R.-fdist T).
+Variables (X : {RV P -> A}) (f : A -> B).
+Variables (a : A).
 
-Lemma pr_RV2_comp :
-  `Pr[ [% Z, Y] = (f y, y) ] = `Pr[ Y = y ].
+Lemma pr_RV2_comp : `Pr[ [% f `o X, X] = (f a, a) ] = `Pr[ X = a ].
 Proof.
-rewrite 2!pr_eqE.
-congr (Pr _ _).
+rewrite 2!pr_eqE; congr (Pr _ _).
 apply/setP => t.
-rewrite !inE xpair_eqE.
-by rewrite andb_idl// => /eqP <-.
+by rewrite !inE xpair_eqE andb_idl// => /eqP <-.
 Qed.
 
 End pr_RV2_comp.

--- a/probability/proba.v
+++ b/probability/proba.v
@@ -848,7 +848,7 @@ Qed.
 
 End pr_pair.
 
-Section more_pr_lemmas.
+Section pr_in_comp'.
 Context {R : realType}.
 Variables (U : finType) (P : R.-fdist U).
 Variables (TA UA : finType) (f : TA -> UA) (X : {RV P -> TA}).
@@ -870,7 +870,27 @@ apply: eq_bigl=> j.
 by rewrite !inE.
 Qed.
 
-End more_pr_lemmas.
+End pr_in_comp'.
+
+Section pr_comp_removal.
+Context {R : realType}.
+Variables (T TX TY TZ : finType).
+Variable P : R.-fdist T.
+Variables (X : {RV P -> TX}) (Y : {RV P -> TY}) (f : TY -> TZ).
+Variables (y : TY) (z : TZ).
+Let Z := f `o Y.
+
+Lemma pr_comp_removal :
+  `Pr[ [% Z, Y] = (f y, y) ] = `Pr[ Y = y ].
+Proof.
+rewrite 2!pr_eqE.
+congr (Pr _ _).
+apply/setP => t.
+rewrite !inE xpair_eqE.
+by rewrite andb_idl// => /eqP <-.
+Qed.
+
+End pr_comp_removal.
 
 Lemma pr_eq_pair_setT {R : realType} (U : finType) (P : R.-fdist U)
     (A B : finType) (E : {set A}) (X : {RV P -> A}) (Y : {RV P -> B}) :

--- a/probability/proba.v
+++ b/probability/proba.v
@@ -872,7 +872,7 @@ Qed.
 
 End pr_in_comp'.
 
-Section pr_comp_removal.
+Section pr_RV2_comp.
 Context {R : realType}.
 Variables (T TX TY TZ : finType).
 Variable P : R.-fdist T.
@@ -880,7 +880,7 @@ Variables (X : {RV P -> TX}) (Y : {RV P -> TY}) (f : TY -> TZ).
 Variables (y : TY) (z : TZ).
 Let Z := f `o Y.
 
-Lemma pr_comp_removal :
+Lemma pr_RV2_comp :
   `Pr[ [% Z, Y] = (f y, y) ] = `Pr[ Y = y ].
 Proof.
 rewrite 2!pr_eqE.
@@ -890,7 +890,7 @@ rewrite !inE xpair_eqE.
 by rewrite andb_idl// => /eqP <-.
 Qed.
 
-End pr_comp_removal.
+End pr_RV2_comp.
 
 Lemma pr_eq_pair_setT {R : realType} (U : finType) (P : R.-fdist U)
     (A B : finType) (E : {set A}) (X : {RV P -> A}) (Y : {RV P -> B}) :


### PR DESCRIPTION
In this PR I port the modified proposition 2.2.1 of [Iwamoto2024](https://www.jstage.jst.go.jp/article/transfun/E107.A/3/E107.A_2023TAI0001/_pdf). We formalized the proposition in the last meeting on May 9th, after we realized that this part doesn't depend on surjectivity and injectivity.