### PR TITLE
Backport two basic lemmas pr_eq_diag and cPr_eq_id from SMC to infotheo master

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,9 @@
 - in information_theory/entropy.v
   + add injective_joint_entropy_RV
 
+- in probability/proba.v
+  + pr_eq_diag, cPr_eq_id
+
 -------------------
 from 0.9.2 to 0.9.3
 -------------------

--- a/probability/proba.v
+++ b/probability/proba.v
@@ -787,6 +787,11 @@ apply eq_big => // -[a c]; rewrite inE => /andP[/= aE cF].
 by rewrite fdistmapE.
 Qed.
 
+Lemma pr_eq_diag {R : realType} (T : finType) (U : eqType) (P : R.-fdist T)
+(X : {RV P -> U}) (x : U) : `Pr[ [% X, X] = (x, x) ] = `Pr[ X = x ].
+Proof. by rewrite !pr_eqE /Pr; apply: eq_bigl=> a; rewrite !inE xpair_eqE andbb.
+Qed.
+
 Section pr_pair.
 Context {R : realType}.
 Variables (U : finType) (P : R.-fdist U).
@@ -1795,6 +1800,10 @@ Proof.
 rewrite cPr_eq_def /cPr /dist_of_RV 2!pr_eqE; congr (Pr _ _ / _).
 by apply/setP => u; rewrite !inE xpair_eqE.
 Qed.
+
+Lemma cPr_eq_id {R : realType} (T : finType) (U : eqType) (P : R.-fdist T)
+(X : {RV P -> U}) (x : U) : `Pr[ X = x ] != 0 -> `Pr[ X = x | X = x ] = 1.
+Proof. by move=> ?; rewrite cpr_eqE pr_eq_diag divff. Qed.
 
 Section crandom_variable_finType.
 Context {R : realType}.


### PR DESCRIPTION
Because these two are basic lemmas as basic as other lemmas already in Infotheo, like pr_eq_ge0  and cpr_eq_unit_RV, so try to merge them to the master.
