### PR TITLE
refactor string_entropy and entropy_convex

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ information theory, and linear error-correcting codes.
   - [CoqInterval](https://gitlab.inria.fr/coqinterval)
 - Coq namespace: `infotheo`
 - Related publication(s):
-  - [Robust Mean Estimation by All Means (short paper)]() 
+  - [Robust Mean Estimation by All Means (short paper)]()
   - [Trimming Data Sets: a Verified Algorithm for Robust Mean Estimation](https://dl.acm.org/doi/abs/10.1145/3479394.3479412) doi:[10.1145/3479394.3479412](https://doi.org/10.1145/3479394.3479412)
   - [Formal Adventures in Convex and Conical Spaces](https://arxiv.org/abs/2004.12713) doi:[10.1007/978-3-030-53518-6_2](https://doi.org/10.1007/978-3-030-53518-6_2)
   - [A Library for Formalization of Linear Error-Correcting Codes](https://link.springer.com/article/10.1007/s10817-019-09538-8) doi:[10.1007/s10817-019-09538-8](https://doi.org/10.1007/s10817-019-09538-8)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,12 @@
+* added
+
+- in lib/realType_ext.v
+  + definitions `i01_of_prob`, `prob_of_i01`
+  + lemmas `i01_of_probK`, `prob_of_i01K`
+
+- in probability/convex.v
+  + lemma `mc_convRE`
+
 * changed:
 - fdist_gt0, fdist_lt1 (from Prop to bool)
 

--- a/coq-infotheo.opam
+++ b/coq-infotheo.opam
@@ -22,7 +22,7 @@ build: [
 install: [make "install"]
 depends: [
   "coq" { (>= "8.19" & < "8.21~") | (= "dev") }
-  "coq-mathcomp-ssreflect" { (>= "2.3.0") & (< "2.5~") }
+  "coq-mathcomp-ssreflect" { (>= "2.3.0" & < "2.5~") | (= "dev") }
   "coq-mathcomp-fingroup"
   "coq-mathcomp-algebra"
   "coq-mathcomp-solvable"

--- a/coq-infotheo.opam
+++ b/coq-infotheo.opam
@@ -27,8 +27,8 @@ depends: [
   "coq-mathcomp-algebra"
   "coq-mathcomp-solvable"
   "coq-mathcomp-field"
-  "coq-mathcomp-analysis" { (>= "1.11.0") }
-  "coq-mathcomp-reals-stdlib" { (>= "1.11.0") }
+  "coq-mathcomp-analysis" { (>= "1.12.0") | (= "dev") }
+  "coq-mathcomp-reals-stdlib" { (>= "1.12.0") | (= "dev") }
   "coq-hierarchy-builder" { >= "1.9.1" }
   "coq-mathcomp-algebra-tactics" { >= "1.2.0" }
   "coq-interval" { >= "4.10.0"}

--- a/coq-infotheo.opam
+++ b/coq-infotheo.opam
@@ -27,9 +27,9 @@ depends: [
   "coq-mathcomp-algebra"
   "coq-mathcomp-solvable"
   "coq-mathcomp-field"
-  "coq-mathcomp-analysis" { (>= "1.10.0") }
-  "coq-mathcomp-reals-stdlib" { (>= "1.10.0") }
-  "coq-hierarchy-builder" { >= "1.7.0" & < "1.9.1" }
+  "coq-mathcomp-analysis" { (>= "1.11.0") }
+  "coq-mathcomp-reals-stdlib" { (>= "1.11.0") }
+  "coq-hierarchy-builder" { >= "1.9.1" }
   "coq-mathcomp-algebra-tactics" { >= "1.2.0" }
   "coq-interval" { >= "4.10.0"}
 ]

--- a/information_theory/entropy_convex.v
+++ b/information_theory/entropy_convex.v
@@ -228,22 +228,6 @@ Section realType.
 Variable R : realType.
 Local Notation H2 := (@H2 R^o : R^o -> R^o).
 
-From mathcomp Require Import -(notations) convex.
-
-(* TODO: introduce two notations and make two conventions more symmetric *)
-(* TODO: use mc_convE in string_entropy.v instead of conv_conv (or the other way) *)
-Definition prob_itv (p : {prob R}) :
-  Itv.def (@Itv.num_sem R) (Itv.Real `[(ssrint.Posz 0), (ssrint.Posz 1)]).
-Proof.
-exists (Prob.p p) => /=; apply/andP; split.
-  by rewrite num_real.
-by rewrite in_itv /=; apply/andP; split.
-Defined.
-
-Lemma conv_conv (x y : R^o) (p : {prob R}) :
-  x <| p |> y = mathcomp.analysis.convex.conv (prob_itv p) x y.
-Proof. by []. Qed.
-
 Lemma concavity_of_entropy_x_le_y x y (t : {prob R}) :
   x \in `]0, 1[%classic -> y \in `]0, 1[%classic -> x < y ->
   concave_function_at H2 x y t.
@@ -261,9 +245,8 @@ have cnH2: {within `[x, y], continuous (- H2)}%classic.
   by apply: continuous_in_subspaceT=> z /zxycc01 /continuous_H2 /continuousN.
 apply/RNconcave_function_at.
 rewrite /convex_function_at /=.
-rewrite !conv_conv.
-have:= @mathcomp.analysis.convex.second_derivative_convex R (fun z => - (H2 z)) x y.
-apply.
+rewrite -!mc_convRE.
+apply: (@analysis.convex.second_derivative_convex _ (fun z => - (H2 z))).
 - move=> z xzy.
   have/zxyoo01 z01: z \in `]x, y[%classic by rewrite inE.
   by rewrite DDnH2E// DDnH2_nonneg.

--- a/information_theory/string_entropy.v
+++ b/information_theory/string_entropy.v
@@ -2,7 +2,6 @@
 (* Copyright (C) 2020 infotheo authors, license: LGPL-2.1-or-later            *)
 From mathcomp Require Import all_ssreflect ssralg ssrnum.
 From mathcomp Require Import classical_sets reals exp interval_inference.
-From mathcomp Require convex.
 Require Import ssr_ext ssralg_ext realType_ext realType_ln.
 Require Import fdist entropy convex jensen num_occ.
 
@@ -33,40 +32,18 @@ Import Order.POrderTheory GRing.Theory Num.Theory.
 (* coercions to R : realType do not seem to work *)
 Local Notation "x /:R y" := (x%:R / y%:R) (at level 40, left associativity).
 
-(* TODO: move to convex ? *)
 Section log_concave.
-Import (canonicals) analysis.convex.
 Variable R : realType.
 
-Definition i01_of_prob : {prob R} -> {i01 R}.
-case => p H; exists p => /=.
-by apply/andP; split => //; exact: num_real.
-Defined.
-Definition prob_of_i01 : {i01 R} -> {prob R}.
-by case => p /andP[_ H]; exists p => //.
-Defined.
-
-Lemma i01_of_probK : cancel i01_of_prob prob_of_i01.
-Proof.
-by case => p H /=; case: (elimTF _ _) => /= _ ?; exact/val_inj.
-Qed.
-Lemma prob_of_i01K : cancel prob_of_i01 i01_of_prob.
-Proof.
-by case=> p H/=; case: (elimTF _ _) => _ ?; apply/val_inj.
-Qed.
-
-Lemma mc_convE (a b : R^o) (p : {prob R}) :
-  conv p a b = mathcomp.analysis.convex.conv (i01_of_prob p) a b :> R^o.
-Proof. by case: p. Qed.
-
 (* TODO: already in MathComp-Analysis?*)
+(* TODO: move to convex_analysis.v *)
 Lemma log_concave : concave_function_in Rpos_interval (log : R^o -> R^o).
 Proof.
 move=> /= x y p Hx Hy.
 rewrite /concave_function_at /convex_function_at.
 rewrite !inE in Hx Hy.
 have Hln := concave_ln (i01_of_prob p) Hx Hy.
-rewrite -!mc_convE in Hln.
+rewrite !mc_convRE in Hln.
 rewrite conv_leoppD leoppP /= /log /Log /=.
 rewrite [in X in X <= _]avgRE !mulrA -mulrDl -avgRE.
 by rewrite ler_wpM2r // invr_ge0 ln2_ge0.

--- a/lib/realType_ext.v
+++ b/lib/realType_ext.v
@@ -916,3 +916,22 @@ Lemma s_of_gt0_oprob  p q : 0 < Prob.p [s_of p, q].
 Proof. by rewrite s_of_gt0// oprob_neq0. Qed.
 
 End oprob_lemmas2.
+
+Section i01_prob.
+Variable R : realType.
+
+Definition i01_of_prob (p : {prob R}) : {i01 R} :=
+  Itv01 (prob_ge0 p) (prob_le1 p).
+
+Let _prob_of_i01 (p : {i01 R}) :=
+      fun q => @Prob.mk _ p%:num (introTF andP q).
+Definition prob_of_i01 (p : {i01 R}) : {prob R} :=
+  _prob_of_i01 (conj (ge0 p) (le1 p)).
+
+Lemma i01_of_probK : cancel i01_of_prob prob_of_i01.
+Proof. by move=> p; apply/val_inj. Qed.
+
+Lemma prob_of_i01K : cancel prob_of_i01 i01_of_prob.
+Proof. by move=>p; apply/val_inj. Qed.
+
+End i01_prob.

--- a/probability/convex.v
+++ b/probability/convex.v
@@ -7,6 +7,7 @@ From mathcomp Require Import ssrnum archimedean ereal interval_inference.
 From mathcomp Require Import ring lra reals.
 Require Import ssr_ext ssralg_ext realType_ext realType_ln fdist.
 From mathcomp Require vector.
+From mathcomp.analysis Require Import (canonicals)convex.
 
 (**md**************************************************************************)
 (* # Convexity                                                                *)
@@ -3224,3 +3225,15 @@ by apply/mulr_ge0; rewrite subr_ge0; exact/ltW.
 Qed.
 
 End twice_derivable_convex.
+
+(* mc_convRE == a <|p|> b (mathcomp_analysis) = a <|p|> b (infotheo) :> R *)
+Section mc_conv.
+Local Open Scope ring_scope.
+Import (canonicals) analysis.convex.
+Variable R : realType.
+
+Lemma mc_convRE (a b : R^o) (p : {prob R}) :
+  mathcomp.analysis.convex.conv (i01_of_prob p) a b = conv p a b :> R^o.
+Proof. by []. Qed.
+
+End mc_conv.

--- a/probability/convex.v
+++ b/probability/convex.v
@@ -1,7 +1,7 @@
 (* infotheo: information theory and error-correcting codes in Coq             *)
 (* Copyright (C) 2020 infotheo authors, license: LGPL-2.1-or-later            *)
 From HB Require Import structures.
-From mathcomp Require Import all_ssreflect ssralg fingroup perm matrix.
+From mathcomp Require Import all_ssreflect ssralg fingroup perm matrix interval.
 From mathcomp Require Import unstable mathcomp_extra boolp classical_sets.
 From mathcomp Require Import ssrnum archimedean ereal interval_inference.
 From mathcomp Require Import ring lra reals.
@@ -3107,8 +3107,6 @@ have -> : ((x - a) / (b - a) = (Prob.p t).~)%R.
   by rewrite addrC.
 by rewrite lexx.
 Qed.
-
-From mathcomp Require Import interval.
 
 Lemma second_derivative_convexf_pt : forall t : {prob R}, convex_function_at f a b t.
 Proof.


### PR DESCRIPTION
`string_entropy` and `entropy_convex` had been handling mathcomp.convex similarly but parallelly.
(i.e. `prob` <-> `i01` and `conv` <-> `analysis.conv`
This PR unifies these definitions and moves them to appropriate files.
