### PR TITLE
proactive fixes towards rocq 9.0

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -19,7 +19,6 @@ jobs:
         image:
           - 'mathcomp/mathcomp:2.3.0-coq-8.20'
           - 'mathcomp/mathcomp:2.4.0-coq-8.20'
-          - 'mathcomp/mathcomp:2.3.0-rocq-prover-9.0'
           - 'mathcomp/mathcomp:2.4.0-rocq-prover-9.0'
           - 'mathcomp/mathcomp-dev:rocq-prover-dev'
       fail-fast: false

--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -19,7 +19,8 @@ jobs:
         image:
           - 'mathcomp/mathcomp:2.3.0-coq-8.20'
           - 'mathcomp/mathcomp:2.4.0-coq-8.20'
-	  - 'mathcomp/mathcomp:2.4.0-rocq-prover-9.0'
+          - 'mathcomp/mathcomp:2.3.0-rocq-prover-9.0'
+          - 'mathcomp/mathcomp:2.4.0-rocq-prover-9.0'
           - 'mathcomp/mathcomp-dev:rocq-prover-dev'
       fail-fast: false
     steps:

--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -17,9 +17,9 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'mathcomp/mathcomp:2.3.0-coq-8.19'
           - 'mathcomp/mathcomp:2.3.0-coq-8.20'
           - 'mathcomp/mathcomp:2.4.0-coq-8.20'
+	  - 'mathcomp/mathcomp:2.4.0-rocq-prover-9.0'
           - 'mathcomp/mathcomp-dev:rocq-prover-dev'
       fail-fast: false
     steps:

--- a/coq-infotheo.opam
+++ b/coq-infotheo.opam
@@ -21,7 +21,7 @@ build: [
 ]
 install: [make "install"]
 depends: [
-  "coq" { (>= "8.20" & <= "9.0") | (= "dev") }
+  "coq" { (>= "8.20" & < "9.1") | (= "dev") }
   "coq-mathcomp-ssreflect" { (>= "2.3.0" & < "2.5~") | (= "dev") }
   "coq-mathcomp-fingroup"
   "coq-mathcomp-algebra"

--- a/coq-infotheo.opam
+++ b/coq-infotheo.opam
@@ -21,7 +21,7 @@ build: [
 ]
 install: [make "install"]
 depends: [
-  "coq" { (>= "8.20" & < "8.21~") | (= "dev") }
+  "coq" { (>= "8.20" & <= "9.0") | (= "dev") }
   "coq-mathcomp-ssreflect" { (>= "2.3.0" & < "2.5~") | (= "dev") }
   "coq-mathcomp-fingroup"
   "coq-mathcomp-algebra"

--- a/information_theory/kraft.v
+++ b/information_theory/kraft.v
@@ -1,7 +1,7 @@
 (* infotheo: information theory and error-correcting codes in Coq             *)
 (* Copyright (C) 2020 infotheo authors, license: LGPL-2.1-or-later            *)
 From mathcomp Require Import all_ssreflect ssralg ssrnum.
-Require FunctionalExtensionality.
+Require FunctionalExtensionality Wf_nat.
 Require Import ssr_ext.
 
 (**md**************************************************************************)

--- a/information_theory/source_coding_fl_converse.v
+++ b/information_theory/source_coding_fl_converse.v
@@ -123,11 +123,11 @@ apply (@le_trans _ _ (2%R `^ n%:R)%R).
   have Hsubset : [set x | dec sc (enc sc x) == x] \subset dec sc @: (enc sc @: [set: 'rV[A]_k.+1]).
     apply/subsetP => x; rewrite inE => /eqP Hx.
     by apply/imsetP; exists (enc sc x) => //; rewrite imset_f.
-  apply (@le_trans _ _ #| dec sc @: (enc sc @: [set: 'rV[A]_k.+1]) |%:R).
+  apply: (@le_trans _ _ #| dec sc @: (enc sc @: [set: 'rV[A]_k.+1]) |%:R).
     by rewrite ler_nat; case/subset_leqif_cards : Hsubset.
-  apply (@le_trans _ _ #| dec sc @: [set: 'rV[bool]_n] |%:R).
+  apply: (@le_trans _ _ #| dec sc @: [set: 'rV[bool]_n] |%:R).
     by rewrite ler_nat; apply/subset_leqif_cards/imsetS/subsetP => x Hx; rewrite inE.
-  apply (@le_trans _ _ #| [set: 'rV[bool]_n] |%:R).
+  apply: (@le_trans _ _ #| [set: 'rV[bool]_n] |%:R).
     by rewrite ler_nat; exact/leq_imset_card.
   rewrite cardsT card_mx /= card_bool mul1n.
   by rewrite powR_mulrn// natrX.

--- a/lib/euclid.v
+++ b/lib/euclid.v
@@ -1,6 +1,7 @@
 (* infotheo: information theory and error-correcting codes in Coq             *)
 (* Copyright (C) 2020 infotheo authors, license: LGPL-2.1-or-later            *)
 From mathcomp Require Import all_ssreflect ssralg poly polydiv matrix.
+Require Bool.
 
 (**md**************************************************************************)
 (* # Euclidean algorithm for decoding                                         *)

--- a/lib/hamming.v
+++ b/lib/hamming.v
@@ -648,33 +648,19 @@ Lemma wHb_1 : forall n l, size l = n ->
   exists i, (i < n /\ l `b_ i = true)%nat /\
     forall j, (j < n -> j <> i -> l `b_ j = false)%nat.
 Proof.
-elim.
-- by case.
-- move=> n IH [|[] t] // [Hsz] /=.
-  + case=> H.
-    exists O.
-    split; first by [].
-    move=> j Hj Hj'.
-    destruct j => //=.
-    move: (has_count (pred1 true) t).
-    rewrite /HammingBitstring.wH /num_occ in H.
-    rewrite H ltnn.
-    move/negbT/hasPn => K.
-    move: (@mem_nth _ false t j).
-    rewrite ltnS in Hj.
-    rewrite Hsz.
-    move/(_ Hj).
-    move/K => /= {}K.
-    apply Bool.not_true_is_false.
-    by apply/eqP.
-  + rewrite add0n.
-    case/(IH _ Hsz) => i [[H11 H12] H2].
-    exists i.+1%N.
-    split; first by [].
-    move=> j Hj Hj'.
-    destruct j => //=.
-    apply H2 => //.
-    contradict Hj'; by subst j.
+move=> n l <-.
+elim: l=> // -[] /= l IHl.
+  rewrite add1n; case => /eqP.
+  rewrite /HammingBitstring.wH -notin_num_occ_0.
+  move/(nthP false)/boolp.forallPNP => lfalse.
+  exists 0; split=> // j /[swap] /eqP.
+  rewrite -lt0n ltnS => /prednK <- jl /=.
+  have:= lfalse j.-1 jl.
+  by move/negP/negPf.
+rewrite add0n => /IHl -[] i [[il itrue] lfalse].
+exists i.+1; rewrite ltnS /=; split=> // -[] //= j.
+rewrite ltnS => jl /eqP /[!eqSS] /eqP ji.
+exact: lfalse.
 Qed.
 
 Lemma wH_1 n (x : 'rV['F_2]_n) : wH x = 1%nat ->

--- a/probability/convex_stone.v
+++ b/probability/convex_stone.v
@@ -967,12 +967,13 @@ have D'1 : (\sum_(i < 3) (D' i) = 1).
     by rewrite prednK // (leq_trans _ j1).
   apply eq_big => //= i.
   rewrite /h' /h.
-  by apply/eqP/val_inj => /=; rewrite inordK.
+  by apply/eqP/val_inj => /=; rewrite add0n inordK.
 set D := FDist.make D'0 D'1.
 have H1 : (fdist_del dmax1) ord0 != 1%R.
   rewrite fdist_delE fdistD1E (eq_sym (lift _ _)) (negbTE (neq_lift _ _)).
   apply/eqP.
-  move/divr1_eq. exact/eqP.
+  move/divr1_eq.
+  exact/eqP.
 pose G : 'I_3 -> A := [eta (fun=>g ord0) with
   ord0 |-> g ord0,
   lift ord0 ord0 |-> g (lift ord0 ord0),

--- a/probability/convex_stone.v
+++ b/probability/convex_stone.v
@@ -967,7 +967,7 @@ have D'1 : (\sum_(i < 3) (D' i) = 1).
     by rewrite prednK // (leq_trans _ j1).
   apply eq_big => //= i.
   rewrite /h' /h.
-  by apply/eqP/val_inj => /=; rewrite add0n inordK.
+  by rewrite inord_val eqxx.
 set D := FDist.make D'0 D'1.
 have H1 : (fdist_del dmax1) ord0 != 1%R.
   rewrite fdist_delE fdistD1E (eq_sym (lift _ _)) (negbTE (neq_lift _ _)).


### PR DESCRIPTION
This PR is a collection of minor fixes for incompatibilities that prevent compilation with rocq 9.
All but `convex_equiv` is fixed. (`convex_equiv` would need a major rewrite.)