### PR TITLE
fix convex_equiv for rocq 9

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,15 @@
+* changed
+
+- in convex_equiv.v
+  + removed the large module NaryConvexSpace and
+    put its parts into separate modules;
+    replaced ML-style functors by HB structures and instances
+
+* renamed
+
+- in convex_equiv.v
+  + naryConvType -> naryStdType
+
 * added
 
 - in entropy.v

--- a/probability/convex_equiv.v
+++ b/probability/convex_equiv.v
@@ -273,7 +273,12 @@ Qed.
 Lemma binconvmm p a : binconv p a a = a.
 Proof. by apply: axidem => i; case: ifP. Qed.
 
+(*
+(* This instantiation breaks the compilation of the next module on Coq 8.20 *)
 HB.instance Definition _ := @isConvexSpace.Build R C binconv
+  binconv1 binconvmm binconvC binconvA.
+*)
+Definition binconv_mixin := @isConvexSpace.Build R C binconv
   binconv1 binconvmm binconvC binconvA.
 
 End instance.
@@ -314,6 +319,9 @@ Import NaryToBin.
 (* We do not need to import BinToNary here because exactly
    the same construction (Convn) is already in convex.v with a
    handy notation <|>_ d g *)
+
+(* On Rocq 9.0, this intantiation can be done in Module NaryToBin *)
+HB.instance Definition _ := binconv_mixin T.
 
 (* The LHS is native to T; the RHS is obtained through NaryToBin *)
 Lemma equiv_convn n (d : R.-fdist 'I_n) (g : 'I_n -> T) : <&>_d g = <|>_d g.

--- a/probability/convex_equiv.v
+++ b/probability/convex_equiv.v
@@ -14,11 +14,11 @@ Require Import ssr_ext ssralg_ext realType_ext fdist jfdist_cond fsdist convex.
 (*   conical spaces. CICM 2020                                                *)
 (*                                                                            *)
 (* ```                                                                        *)
-(*   naryConvType == type that provides a nary operator intended to represent *)
+(*    naryStdType == type that provides a nary operator intended to represent *)
 (*                   nary convex combinations as found in standard convex     *)
 (*                   spaces such as [Bonchi 2017]; different axiomatics are   *)
-(*                   possible, they are provided with their equivalences by   *)
-(*                   the module NaryConvexSpaceEquiv                          *)
+(*                   possible, they are provided with their equivalences in   *)
+(*                   this file                                                *)
 (*        <&>_d f == notation for the operator of naryConvType                *)
 (*    a <& p &> b == binary instance of the <&>_ operator                     *)
 (* ```                                                                        *)
@@ -39,130 +39,172 @@ Local Open Scope reals_ext_scope.
 Local Open Scope fdist_scope.
 Local Open Scope convex_scope.
 
-Module NaryConvexSpace.
+(* In this file, we use funext to avoid explicitly handling the congruence
+   of convn (cf. eq_convn in convex_choice.v for the iterated version). *)
 
-HB.mixin Record isNaryConv (T : Type) of Choice T := {
-  convn : forall n, {fdist 'I_n} -> ('I_n -> T) -> T
+(* We will prove:
+   binary axioms <-> ax_barycenter + ax_proj <-> ax_part + ax_idem
+                 <-> ax_barycenter + ax_map + ax_const <-> ax_barycenter_part + ax_idem
+   TODO: but (ax_barycenter + ax_const) and (ax_part + ax_proj) are weaker
+   Note that we have ax_idem -> ax_proj and ax_idem -> ax_const.
+ *)
+
+
+(* isNaryConv is a basic structure carrying just an n-ary convex opreator.
+   This is going to be combined with various axioms *)
+
+HB.mixin Record hasNaryOp (R : realType) (T : Type) of Choice T := {
+  convn : forall n, (R.-fdist 'I_n) -> ('I_n -> T) -> T
 }.
 
-#[short(type=naryConvType)]
-HB.structure Definition NaryConv := {T of isNaryConv T &}.
+#[short(type=naryOpType)]
+HB.structure Definition NaryOp R := {T of hasNaryOp R T &}.
 
 Notation "'<&>_' d f" := (convn _ d f) : convex_scope.
 
-End NaryConvexSpace.
 
-Module NaryConvexSpaceEquiv.
-Import NaryConvexSpace.
+(* n-ary axioms we deal with in this file *)
 
-(* In this module we use funext to avoid explicitly handling the congruence
-   of convn (cf. eq_convn in convex_choice.v for the iterated version). *)
+Module NaryLaws.
+Section axioms.
 
-Section Axioms.
-Variable T : naryConvType.
+Variables (R : realType) (T : naryOpType R).
 
 Definition ax_bary :=
-  forall n m (d : {fdist 'I_n}) (e : 'I_n -> {fdist 'I_m}) (g : 'I_m -> T),
+  forall n m (d : R.-fdist 'I_n) (e : 'I_n -> R.-fdist 'I_m) (g : 'I_m -> T),
     <&>_d (fun i => <&>_(e i) g) = <&>_(fdist_convn d e) g.
 Definition ax_proj :=
   forall  n (i : 'I_n) (g : 'I_n -> T), <&>_(fdist1 i) g = g i.
 
 (* Beaulieu's version [Beaulieu PhD 2008] *)
 Definition ax_part :=
-  forall n m (K : 'I_m -> 'I_n) (d : {fdist 'I_m}) (g : 'I_m -> T),
+  forall n m (K : 'I_m -> 'I_n) (d : R.-fdist 'I_m) (g : 'I_m -> T),
     <&>_d g = <&>_(fdistmap K d) (fun i => <&>_(FDistPart.d K d i) g).
 Definition ax_idem :=
-  forall (a : T) (n : nat) (d : {fdist 'I_n}) (g : 'I_n -> T),
+  forall (a : T) (n : nat) (d : R.-fdist 'I_n) (g : 'I_n -> T),
     (forall i, i \in fdist_supp d -> g i = a) -> <&>_d g = a.
 
 (* Alternative to ax_proj *)
 Definition ax_map :=
-  forall (n m : nat) (u : 'I_m -> 'I_n) (d : {fdist 'I_m}) (g : 'I_n -> T),
+  forall (n m : nat) (u : 'I_m -> 'I_n) (d : R.-fdist 'I_m) (g : 'I_n -> T),
     <&>_d (g \o u) = <&>_(fdistmap u d) g.
 Definition ax_const :=
-  forall (a : T) (n : nat) (d : {fdist 'I_n}),
+  forall (a : T) (n : nat) (d : R.-fdist 'I_n),
     <&>_d (fun _ => a) = a.
 
 (* Alternative to ax_part, just a restriction of ax_barycenter *)
 Definition ax_bary_part :=
-  forall n m (d : {fdist 'I_n}) (e : 'I_n -> {fdist 'I_m}) (g : 'I_m -> T),
+  forall n m (d : R.-fdist 'I_n) (e : 'I_n -> R.-fdist 'I_m) (g : 'I_m -> T),
     (forall i j, i != j ->
                  fdist_supp (e i) :&: fdist_supp (e j) = finset.set0) ->
     <&>_d (fun i => <&>_(e i) g) = <&>_(fdist_convn d e) g.
 
 (* Restriction of ax_map to injective maps *)
 Definition ax_inj_map :=
-  forall (n m : nat) (u : 'I_m -> 'I_n) (d : {fdist 'I_m}) (g : 'I_n -> T),
+  forall (n m : nat) (u : 'I_m -> 'I_n) (d : R.-fdist 'I_m) (g : 'I_n -> T),
     injective u -> <&>_d (g \o u) = <&>_(fdistmap u d) g.
-End Axioms.
 
-(* We will prove:
-   binary axioms <-> ax_barycenter + ax_proj <-> ax_part + ax_idem
-                 <-> ax_barycenter + ax_map + ax_const <-> ax_barycenter_part + ax_idem
-   but (ax_barycenter + ax_const) and (ax_part + ax_proj) are weaker.
-   Note that we have ax_idem -> ax_proj and ax_idem -> ax_const.
- *)
+End axioms.
+End NaryLaws.
 
-Module Type NaryConvSpace.
-Parameter T : naryConvType.
-Parameter axbary : ax_bary T.
-Parameter axproj : ax_proj T.
-End NaryConvSpace.
+Import NaryLaws.
 
-Module Type ConvSpace. Axiom T : convType Rdefinitions.R. End ConvSpace.
 
-(* First prove mutual definability using ax_barycenter / ax_proj *)
+(* What we refer to the "standard" theory in our CICM paper *)
 
-Module BinToNary(C : ConvSpace) <: NaryConvSpace.
-Import NaryConvexSpace.
+HB.mixin Record isNaryStd
+  (R : realType) (T : Type) of Choice T & NaryOp R T := {
+  axbary : ax_bary T;
+  axproj : ax_proj T;
+}.
 
-HB.instance Definition _ := @isNaryConv.Build C.T (@Convn Rdefinitions.R C.T conv).
+#[short(type=naryStdType)]
+HB.structure Definition NaryStd (R : realType) :=
+  {T of isNaryStd R T &}.
 
-(* NB: is that ok? *)
-Definition T : naryConvType := C.T.
-Definition axbary := @Convn_fdist_convn Rdefinitions.R C.T.
-Definition axproj := @Convn_fdist1 Rdefinitions.R C.T.
+
+(* Another axiomatization by the map and const laws *)
+
+HB.mixin Record isNaryMapConst
+  (R : realType) (T : Type) of Choice T & NaryOp R T := {
+  axmap : ax_map T;
+  axconst : ax_const T;
+}.
+
+#[short(type=naryMapConstType)]
+HB.structure Definition NaryMapConst (R : realType) :=
+  {T of isNaryMapConst R T &}.
+
+
+(* Beaulieu's axiomaization by the part and idem laws *)
+
+HB.mixin Record isNaryBeaulieu
+  (R : realType) (T : Type) of Choice T & NaryOp R T := {
+  axpart : ax_part T;
+  axidem : ax_idem T;
+}.
+
+#[short(type=naryBeaulieuType)]
+HB.structure Definition NaryBeaulieu (R : realType) :=
+  {T of isNaryBeaulieu R T &}.
+
+
+(* First prove mutual definability between convType and naryConvSpace *)
+
+Module BinToNary.
+Section instances.
+Variables (R : realType) (C : convType R).
+
+HB.instance Definition _ := @hasNaryOp.Build R C (@Convn R C conv).
+
+Definition axbary := @Convn_fdist_convn R C.
+Definition axproj := @Convn_fdist1 R C.
+
+HB.instance Definition  _ := @isNaryStd.Build R C axbary axproj.
+
+End instances.
 End BinToNary.
 
-Module NaryToBin(A : NaryConvSpace).
-Export A.
+Module NaryToBin.
+Section instance.
+Variables (R : realType) (C : naryStdType R).
 
 (* axmap, axconst and axidem are consequences of axbary + axproj *)
-Lemma axmap : ax_map T.
+Lemma axmap : ax_map C.
 Proof.
 move=> n m u d g.
 have -> : fdistmap u d = fdist_convn d (fun i : 'I_m => fdist1 (u i)).
   by apply: fdist_ext => /= i; rewrite /fdistmap/= fdistbindE// fdist_convnE.
 rewrite -axbary.
-by congr (<&>_ _ _); apply funext => i /=; rewrite axproj.
+by congr (<&>_ _ _); apply: funext => i /=; rewrite axproj.
 Qed.
 
-Lemma axconst : ax_const T.
+Lemma axconst : ax_const C.
 Proof.
 move=> a n d.
-by rewrite -(axproj (@ord0 0) (fun=>a)) axbary fdist_convn_cst.
+by rewrite -(axproj _ (@ord0 0) (fun=>a)) axbary fdist_convn_cst.
 Qed.
 
-Lemma axidem : ax_idem T.
+Lemma axidem : ax_idem C.
 Proof.
 move=> a n d g Hd.
 have /=[k Hk] := fdist_supp_mem d.
 have -> : g = (fun i => <&>_(fdist1 (if i \in fdist_supp d then k else i)) g).
-  apply funext => i; rewrite axproj.
+  apply: funext => i; rewrite axproj.
   case: ifP => // /Hd ->; by rewrite (Hd k).
 rewrite axbary (_ : fdist_convn _ _ = fdist1 k) ?axproj ?Hd //.
-apply fdist_ext => /= i.
+apply: fdist_ext => /= i.
 rewrite fdist_convnE sum_fdist_supp fdistE.
 under eq_bigr => j /= -> do rewrite fdistE.
 by rewrite -sum_fdist_supp -big_distrl FDist.f1 /= mul1r.
 Qed.
 
 (* axconst is also a corollary of axidem *)
-Corollary axconst' : ax_const T.
-Proof. by move=> a n d; apply axidem. Qed.
+Corollary axconst' : ax_const C.
+Proof. by move=> a n d; apply: axidem. Qed.
 
 (* Definition of conv based on convn *)
-Definition binconv p (a b : T) :=
+Definition binconv p (a b : C) :=
   <&>_(fdistI2 p) (fun x => if x == ord0 then a else b).
 Notation "a <& p &> b" := (binconv p a b).
 
@@ -173,10 +215,10 @@ set g1 := fun x => _.
 set g2 := fun x => _.
 have -> : g1 = g2 \o tperm ord0 (Ordinal (erefl (1 < 2))).
   rewrite /g1 /g2 /=.
-  apply funext => i /=.
+  apply: funext => i /=.
   by case/orP: (ord2 i) => /eqP -> /=; rewrite (tpermL,tpermR).
 rewrite axmap.
-congr (<&>_ _ _); apply fdist_ext => i.
+congr (<&>_ _ _); apply: fdist_ext => i.
 rewrite fdistmapE (bigD1 (tperm ord0 (Ordinal (erefl (1 < 2))) i)) /=; last first.
   by rewrite !inE tpermK.
 rewrite big1 ?addr0.
@@ -185,10 +227,10 @@ rewrite big1 ?addr0.
 by move=> j /andP[] /eqP <-; rewrite tpermK eqxx.
 Qed.
 
-Lemma convn_if A n (p : A -> bool) (d1 d2 : {fdist 'I_n}) (g : _ -> T):
+Lemma convn_if A n (p : A -> bool) (d1 d2 : R.-fdist 'I_n) (g : _ -> C):
   (fun x => if p x then <&>_d1 g else <&>_d2 g) =
   (fun x => <&>_(if p x then d1 else d2) g).
-Proof. apply funext => x; by rewrite (fun_if (fun d => <&>_d g)). Qed.
+Proof. apply: funext => x; by rewrite (fun_if (fun d => <&>_d g)). Qed.
 
 Lemma binconvA p q a b c :
   a <& p &> (b <& q &> c) = (a <& [r_of p, q] &> b) <& [s_of p, q] &> c.
@@ -196,9 +238,9 @@ Proof.
 rewrite /binconv.
 set g := fun i : 'I_3 => if i <= 0 then a else if i <= 1 then b else c.
 rewrite [X in <&>_(fdistI2 q) X](_ : _ = g \o lift ord0); last first.
-  by apply funext => i; case/orP: (ord2 i) => /eqP ->.
+  by apply: funext => i; case/orP: (ord2 i) => /eqP ->.
 rewrite [X in <&>_(fdistI2 [r_of p, q]) X](_ : _ = g \o (widen_ord (leqnSn 2))); last first.
-  by apply funext => i; case/orP: (ord2 i) => /eqP ->.
+  by apply: funext => i; case/orP: (ord2 i) => /eqP ->.
 rewrite 2!axmap.
 set d1 := fdistmap _ _.
 set d2 := fdistmap _ _.
@@ -206,7 +248,7 @@ set ord23 := Ordinal (ltnSn 2).
 have -> : a = g ord0 by [].
 have -> : c = g ord23 by [].
 rewrite -2!axproj 2!convn_if 2!axbary.
-congr (<&>_ _ _); apply fdist_ext => j.
+congr (<&>_ _ _); apply: fdist_ext => j.
 rewrite !fdist_convnE !big_ord_recl !big_ord0 /=.
 rewrite !fdistI2E !fdistmapE !fdist1E !addr0 /=.
 case: j => -[|[|[]]] //= Hj.
@@ -224,30 +266,57 @@ Qed.
 
 Lemma binconv1 a b : binconv 1%:pr a b = a.
 Proof.
-apply axidem => /= i; rewrite inE fdistI2E; case: ifP => //=.
+apply: axidem => /= i; rewrite inE fdistI2E; case: ifP => //=.
 by rewrite /onem subrr eqxx.
 Qed.
 
 Lemma binconvmm p a : binconv p a a = a.
-Proof. by apply axidem => i; case: ifP. Qed.
+Proof. by apply: axidem => i; case: ifP. Qed.
 
-HB.instance Definition _ := @isConvexSpace.Build Rdefinitions.R A.T binconv
+HB.instance Definition _ := @isConvexSpace.Build R C binconv
   binconv1 binconvmm binconvC binconvA.
 
+End instance.
+Notation "a <& p &> b" := (binconv p a b).
 End NaryToBin.
-(*HB.export NaryToBin.
-Error: Anomaly "Uncaught exception Not_found."
-Please report at http://coq.inria.fr/bugs/.
-*)
 
-(* Then prove BinToN and NToBin cancel each other:
-   operations should coincide on both sides *)
 
-Module Equiv2(A : NaryConvSpace).
-Module B := NaryToBin(A).
-Import A B.
+(* Then prove the definitions of operators cancel each other *)
 
-Lemma equiv_convn n (d : {fdist 'I_n}) g : <&>_d g = <|>_d g.
+Module BinToNaryToBin.
+Section proof.
+Variables (R : realType) (C : convType R).
+Import BinToNary NaryToBin.
+
+#[local]
+Fact _equiv_convn n (d : R.-fdist 'I_n) (g : 'I_n -> C) : <&>_d g = <|>_d g.
+Proof. by []. Qed.
+
+(* The LHS is native to C; the RHS is obtained through BinToNary and NaryToBin *)
+Lemma equiv_conv p (a b : C) : a <| p |> b = a <& p &> b.
+Proof.
+pose g := fun (x : 'I_2) => if x == ord0 then a else b.
+change a with (g ord0).
+change b with (g (lift ord0 ord0)).
+pose d := fdistI2 p.
+rewrite [in LHS](_ : p = probfdist d ord0); last first.
+  by apply: val_inj=> /=; rewrite fdistI2E eqxx.
+by rewrite -!ConvnI2E convnE.
+Qed.
+
+End proof.
+End BinToNaryToBin.
+
+Module NaryToBinToNary.
+Section proof.
+Variables (R : realType) (T : naryStdType R).
+Import NaryToBin.
+(* We do not need to import BinToNary here because exactly
+   the same construction (Convn) is already in convex.v with a
+   handy notation <|>_ d g *)
+
+(* The LHS is native to T; the RHS is obtained through NaryToBin *)
+Lemma equiv_convn n (d : R.-fdist 'I_n) (g : 'I_n -> T) : <&>_d g = <|>_d g.
 Proof.
 elim: n d g => [|n IH d g /=].
   by move=> d; move: (fdist_card_neq0 d); rewrite card_ord.
@@ -255,26 +324,26 @@ case: Bool.bool_dec => [|b].
   by rewrite fdist1E1 => /eqP ->; rewrite axproj.
 rewrite -{}IH.
 have -> : (fun i => g (fdist_del_idx ord0 i)) = g \o lift ord0.
-  by apply funext => i; rewrite /fdist_del_idx ltn0.
+  by apply: funext => i; rewrite /fdist_del_idx ltn0.
 apply/esym; rewrite axmap /=.
 rewrite /(_ <| _ |> _)/= /binconv.
 set d' := fdistmap _ _.
-rewrite -(axproj ord0) convn_if axbary.
-congr (<&>_ _ _); apply fdist_ext => i.
+rewrite -(axproj _ ord0) convn_if axbary.
+congr (<&>_ _ _); apply: fdist_ext => i.
 rewrite fdist_convnE !big_ord_recl big_ord0 addr0 /= !fdistI2E /=.
 rewrite fdist1E /d' fdistmapE /=.
 have [->|] := eqVneq i ord0; first by rewrite big1 // mulr0 mulr1 addr0.
 case: (unliftP ord0 i) => //= [j|] -> // Hj.
 rewrite (big_pred1 j) //=.
 rewrite fdist_delE fdistD1E /= /onem.
-rewrite mulr0 add0r mulrA (mulrC (1 - d ord0)%R) mulrK //.
+rewrite mulr0 add0r mulrA (mulrC (1 - d ord0)%R) mulfK //.
 apply/eqP=> /(congr1 (+%R (d ord0))).
 rewrite addrCA addrN !addr0 => b'.
 by elim b; rewrite -b' eqxx.
 Qed.
 
-(*
-Lemma equiv_conv p x y : x <& p &> y = x <| p |> y.
+#[local]
+Corollary _equiv_conv p (x y : T) : x <& p &> y = x <| p |> y.
 Proof.
 rewrite /binconv.
 set g := fun (o : 'I_2) => if o == ord0 then x else y.
@@ -282,48 +351,17 @@ set d := fdistI2 p.
 change x with (g ord0).
 change y with (g (lift ord0 ord0)).
 have -> : p = probfdist d ord0 by apply: val_inj=> /=; rewrite fdistI2E eqxx.
-by rewrite -ConvnI2E -equiv_convn.
-Qed.
-*)
-
-End Equiv2.
-
-Module Equiv1(C : ConvSpace).
-Module A := BinToNary(C).
-Module B := NaryToBin(A).
-Module EA := Equiv2(A).
-Import A B.
-
-#[local]
-Definition equiv_convn n (d : {fdist 'I_n}) (g : 'I_n -> A.T) : <&>_d g = <|>_d g.
-Proof. by []. Qed.
-
-Definition T' := NaryConv_sort__canonical__convex_ConvexSpace.
-
-Lemma equiv_conv p (a b : C.T) : a <| p |> b = a <& p &> b.
-Proof.
-change (a <& p &> b) with (@conv Rdefinitions.R T' p a b).
-pose g := fun (x : 'I_2) => if x == ord0 then a else b.
-change a with (g ord0).
-change b with (g (lift ord0 ord0)).
-pose d := fdistI2 p.
-have -> : p = probfdist d ord0 by apply: val_inj=> /=; rewrite fdistI2E eqxx.
-rewrite -!ConvnI2E.
-rewrite convnE -equiv_convn.
-by rewrite EA.equiv_convn.
+by rewrite -ConvnI2E convnE equiv_convn.
 Qed.
 
-End Equiv1.
+End proof.
+End NaryToBinToNary.
 
-Module Type MapConst.
-Parameter T : naryConvType.
-Parameter axmap : ax_map T.
-Parameter axconst : ax_const T.
-End MapConst.
 
 (* axidem is a consequence of axmap + axconst *)
-Module MapConstToIdem(A : MapConst).
-Import A.
+Module MapConstToIdem.
+Section proof.
+Variables (R : realType) (T : naryMapConstType R).
 
 Lemma axidem : ax_idem T.
 Proof.
@@ -334,7 +372,7 @@ have [x Hx] := fdist_supp_mem d.
 set f' : 'I_n -> 'I_#|supp| := enum_rank_in Hx.
 set d' := fdistmap f' d.
 have -> : d = fdistmap f d'.
-  apply fdist_ext => i /=.
+  apply: fdist_ext => i /=.
   rewrite fdistmap_comp fdistmapE /=.
   case/boolP: (i \in supp) => Hi.
   - rewrite (bigD1 i) /=; last first.
@@ -350,56 +388,46 @@ have -> : d = fdistmap f d'.
     by move: Hi; rewrite -Hj enum_valP.
 rewrite -axmap.
 have -> : g \o f = fun=> a.
-  apply funext => i; rewrite /f /= Ha //.
+  apply: funext => i; rewrite /f /= Ha //.
   by move: (enum_valP i); rewrite inE.
 by rewrite axconst.
 Qed.
+
+End proof.
 End MapConstToIdem.
+
 
 (* Prove equivalence of axioms with Beaulieu's presentation *)
 
-Module Type BeaulieuSpace.
-Parameter T : naryConvType.
-Parameter axpart : ax_part T.
-Parameter axidem : ax_idem T.
-End BeaulieuSpace.
-
-Module StandardToBeaulieu(A : NaryConvSpace) <: BeaulieuSpace.
-Module B := NaryToBin(A).
-Import A B.
-Definition T := A.T.
+Module StandardToBeaulieu.
+Section instance.
+Variables (R : realType) (T : naryStdType R).
 
 Lemma axbarypart : ax_bary_part T.
-Proof. by move=> *; apply axbary. Qed.
+Proof. by move=> *; apply: axbary. Qed.
 
 Lemma axidem : ax_idem T.
-Proof. by move=> a n d g Hd; apply axidem => i; move: (Hd i); rewrite inE. Qed.
+Proof.
+by move=> a n d g Hd; apply: NaryToBin.axidem=> i; move: (Hd i); rewrite inE.
+Qed.
 
 Lemma axpart : ax_part T.
 Proof.
 move=> n m K d g; rewrite axbary; congr (<&>_ _ _).
-by apply fdist_ext => /= j; rewrite !fdistE -FDistPart.dK.
+by apply: fdist_ext => /= j; rewrite !fdistE -FDistPart.dK.
 Qed.
+
+HB.instance Definition _ := isNaryBeaulieu.Build R T axpart axidem.
+
+End instance.
 End StandardToBeaulieu.
 
-Module BeaulieuToStandard(B : BeaulieuSpace) <: NaryConvSpace.
-Import B.
-Definition T := B.T.
+Module BeaulieuToStandard.
+Section instance.
+Variables (R : realType) (T : naryBeaulieuType R).
 
 Lemma axproj : ax_proj T.
-Proof. move=> *; apply axidem => j; by rewrite supp_fdist1 inE => /eqP ->. Qed.
-
-Lemma existb_sig (A : finType) (P : {pred A}) :
-  [exists x, P x] -> {x | P x}.
-Proof.
-move=> He.
-suff: [set x | P x] != finset.set0.
-  case: (set_0Vmem [set x | P x]) => /=[/eqP -> // | [x]].
-  rewrite inE => Hx _; by exists x.
-case/existsP: He => x Px.
-apply/eqP => /setP/(_ x).
-by rewrite inE Px inE.
-Qed.
+Proof. move=> *; apply: axidem => j; by rewrite supp_fdist1 inE => /eqP ->. Qed.
 
 Lemma axbarypart : ax_bary_part T.
 Proof.
@@ -411,10 +439,10 @@ have f j :
   {i | [forall i, j \notin fdist_supp (e (h i))]||(j \in fdist_supp (e (h i)))}.
   case/boolP: [forall i, j \notin fdist_supp (e (h i))].
     by move=> _; exists (proj1_sig (fdist_supp_mem (fdistmap h' d))).
-  by rewrite -negb_exists negbK => /existb_sig.
+  by rewrite -negb_exists negbK => /existsP; exact: sigW.
 rewrite /= in f.
-rewrite [LHS](axpart h').
-rewrite [RHS](axpart (fun j => proj1_sig (f j))).
+rewrite [LHS](axpart _ _ h').
+rewrite [RHS](axpart _ _ (fun j => proj1_sig (f j))).
 have trivIK i j x : x \in fdist_supp (e i) -> x \in fdist_supp (e j) -> i = j.
   have [|] := eqVneq i j => [// | ij] xi xj.
   move/setP/(_ x): (HP _ _ ij); by rewrite inE xi xj inE.
@@ -451,14 +479,14 @@ have Hmap i :
   case: ifPn => [/eqP/esym ->{i}|ji].
     by rewrite (bigD1 (h j)) //= big1 ?addr0 // => *; rewrite (neqj j).
   by rewrite (neqj j) //; apply: contra ji => /eqP/enum_val_inj ->.
-congr (<&>_ _ _); first by apply fdist_ext => /= i; rewrite Hmap.
-apply funext => i /=.
+congr (<&>_ _ _); first by apply: fdist_ext => /= i; rewrite Hmap.
+apply: funext => i /=.
 have HF : fdistmap h' d i != 0%R.
   rewrite fdistE /=.
   apply/eqP => /psumr_eq0P H.
-  have: h i \in fdist_supp d by apply enum_valP.
+  have: h i \in fdist_supp d by apply: enum_valP.
   by rewrite inE H ?eqxx // 2!inE /h /h' enum_valK_in.
-rewrite (@axidem (<&>_(e (h i)) g)); last first.
+rewrite (@axidem _ _ (<&>_(e (h i)) g)); last first.
   move=> /= j; rewrite inE.
   rewrite FDistPart.dE //.
   case/boolP: (j \in fdist_supp d) => [Hj|].
@@ -466,7 +494,7 @@ rewrite (@axidem (<&>_(e (h i)) g)); last first.
       by rewrite /h /h' (enum_rankK_in _ Hj).
     by rewrite mulr0 mul0r eqxx.
   by rewrite inE negbK => /eqP ->; rewrite !mul0r eqxx.
-congr (<&>_ _ _); apply fdist_ext => j.
+congr (<&>_ _ _); apply: fdist_ext => j.
 rewrite FDistPart.dE; last first.
   rewrite !fdistE /=.
   under eq_bigr do rewrite fdistE.
@@ -499,7 +527,7 @@ case: (f j) => /= k /orP[Hn|jk].
     by rewrite inE negbK => /eqP ->; rewrite mulr0.
   by rewrite inE negbK => /eqP ->; rewrite mul0r.
 rewrite (bigD1 (h k)) //= big1 ?addr0; last first.
-  by move=> a Ha; apply (neqj k).
+  by move=> a Ha; apply: (neqj k).
 case/boolP: (j \in fdist_supp (e (h i))) => ji.
   have /enum_val_inj H := trivIK _ _ _ jk ji.
   subst k => {jk}.
@@ -514,9 +542,9 @@ Lemma axinjmap : ax_inj_map T.
 Proof.
 move=> n m u d g Hu.
 have -> : fdistmap u d = fdist_convn d (fun i : 'I_m => fdist1 (u i)).
-  by apply fdist_ext => i; rewrite /fdistmap fdistbindE// fdist_convnE.
+  by apply: fdist_ext => i; rewrite /fdistmap fdistbindE// fdist_convnE.
 rewrite -axbarypart.
-- congr (<&>_ _ _); apply funext => j /=; symmetry; apply axidem => i.
+- congr (<&>_ _ _); apply: funext => j /=; symmetry; apply: axidem => i.
   by rewrite supp_fdist1 inE => /eqP ->.
 - move=> x y xy.
   apply/setP => z.
@@ -534,9 +562,9 @@ set h := fun k i => f (k, i).
 set h' := fun i => snd (f' i).
 rewrite (_ : (fun i => _) = (fun i => <&>_(fdistmap (h i) (e i)) (g \o h')));
   last first.
-  apply funext => i.
+  apply: funext => i.
   have {1}-> : g = (g \o h') \o h i.
-    by apply funext => j; rewrite /h' /h /= /f' /f enum_rankK.
+    by apply: funext => j; rewrite /h' /h /= /f' /f enum_rankK.
   rewrite axinjmap //.
   by move=> x y; rewrite /h => /enum_rank_inj [].
 rewrite axbarypart; first last.
@@ -551,7 +579,7 @@ rewrite axbarypart; first last.
   by move: ij; rewrite -hik /h /f /f' enum_rankK eqxx.
 set e' := fun j => fdistmap f (((fdistX (d `X e)) `(| j)) `x (fdist1 j)).
 have {2}-> : g = (fun j => <&>_(e' j) (g \o h')).
-  apply funext => j; apply/esym/axidem => k //.
+  apply: funext => j; apply/esym/axidem => k //.
   rewrite inE /e' fdistE (big_pred1 (f' k)) /=; last first.
     by move=> i; rewrite 2!inE -{1}(enum_valK k) /f (can_eq enum_rankK).
   rewrite !fdistE.
@@ -569,10 +597,10 @@ rewrite [RHS]axbarypart; last first.
   move: kx ky; rewrite !fdistE.
   case/boolP: ((f' x).2 == i) ij => [/eqP <-|] ij; last by rewrite mulr0 eqxx.
   by case/boolP: ((f' x).2 == j) ij => [/eqP <-|] //; rewrite mulr0 eqxx.
-congr (<&>_ _ _); apply fdist_ext => k.
+congr (<&>_ _ _); apply: fdist_ext => k.
 rewrite /d1 !fdistE.
 under eq_bigr do rewrite fdistE big_distrr big_mkcond /=.
-rewrite exchange_big /=; apply eq_bigr => j _.
+rewrite exchange_big /=; apply: eq_bigr => j _.
 rewrite !fdistE -big_mkcond /=.
 rewrite (big_pred1 (f' k));
   last by move=> a; rewrite !inE -{1}(enum_valK k) /f (can_eq enum_rankK).
@@ -599,6 +627,7 @@ under eq_bigr do rewrite fdist_prodE /=.
 by rewrite -!mulrA mulVf ?mulr1.
 Qed.
 
-End BeaulieuToStandard.
+HB.instance Definition _ := isNaryStd.Build R T axbary axproj.
 
-End NaryConvexSpaceEquiv.
+End instance.
+End BeaulieuToStandard.


### PR DESCRIPTION
This PR fixes broken compilation of `convex_equiv.v` on Rocq 9,
replacing uses of ML-style functors (suspect of the breakage) by HB.
