### PR TITLE
stop using the deprecated factory Order for the order structure on prob

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,9 @@
+* changed
+
+- in realType_ext.v
+  + use [SubChoice_isSubOrder of ...] instead [Order of ...]
+    for the order structure on {prob R}
+
 * added
 
 - in proba.v

--- a/lib/realType_ext.v
+++ b/lib/realType_ext.v
@@ -230,7 +230,8 @@ Lemma probpK R p H : Prob.p (@Prob.mk R p H) = p. Proof. by []. Qed.
 
 Notation "{ 'prob' T }" := (@prob T).
 
-HB.instance Definition _ (R : realType) := [Order of {prob R} by <:].
+HB.instance Definition _ (R : realType) :=
+  [SubChoice_isSubOrder of {prob R} by <: with ring_display].
 
 Definition to_numdomain (R : realType) (p : {prob R}) : Num.NumDomain.sort _ :=
   (p : R).


### PR DESCRIPTION
`{prob R}` has been instantiated as an `orderType` using the factory `Order` fron `order.v`
but this one seems to be deprecated as it is put in a module named `DeprecatedSubOrder`.

Moreover, the structures using `Order` does not work well with the basic lemmas (namely `le_val`, `lt_val`)
for working with suborders.

This PR changes the factory to the newer `SubChoice_isSubOrder` to solve these problems (at least the first, hopefully the second too).