### PR TITLE
fix for mathcomp analysis 1.15

### DIFF
--- a/information_theory/joint_typ_seq.v
+++ b/information_theory/joint_typ_seq.v
@@ -110,7 +110,8 @@ Definition Nup (x : R) := `| Num.floor x |.+1.
 Lemma Nup_gt x : x < (Nup x)%:R.
 Proof.
 apply: (lt_le_trans (floorD1_gt x)).
-rewrite /Nup [leLHS](_ : _ = (Num.Def.floor x)%:~R + 1%:~R) ?intrD1//.
+rewrite /Nup.
+rewrite [leLHS](_ : _ = (Num.Def.floor x)%:~R + 1%:~R); last by rewrite intrD1.
 by rewrite -natr1 lerD // natr_absz ler_int ler_norm.
 Qed.
 

--- a/information_theory/source_coding_vl_converse.v
+++ b/information_theory/source_coding_vl_converse.v
@@ -781,7 +781,7 @@ apply: (@le_trans _ _ ((x ^ 2 / 2 - 1) * eps * n%:R)); last first.
   rewrite lerBlDr.
   rewrite (le_trans (ltW (floorD1_gt _)))//.
   rewrite natr_absz.
-  rewrite [leRHS](_ : _ = (`|floor (expR (m' eps))| + 1)%:~R) -?intrD1//.
+  rewrite [leRHS](_ : _ = (`|floor (expR (m' eps))| + 1)%:~R); last by rewrite intrD1.
   by rewrite ler_int lerD2r ler_norm.
 rewrite logM//; last exact: mpos.
 rewrite -(ler_pM2r ln2_gt0).


### PR DESCRIPTION
This PR is intended for fixing the broken compilation seen in the CI log at https://github.com/math-comp/analysis/pull/1826 .
