### PR TITLE
Adapt to https://github.com/math-comp/math-comp/pull/1456

### DIFF
--- a/information_theory/channel_coding_direct.v
+++ b/information_theory/channel_coding_direct.v
@@ -771,7 +771,7 @@ rewrite ltrD2l.
 have -> : #| M |%:R = 2 `^ (log #| M |%:R) :> R by rewrite LogK // card_ord.
 rewrite -powRD; last by rewrite (eqr_nat R 2 0) implybT.
 rewrite (_ : _ + _ = - n%:R * (`I(P, W) - log #| M |%:R / n%:R - 3 * epsilon0)); last first.
-  field.
+  suff ? : n%:R != 0 :> R by field.
   by case: Hn; rewrite -(ltr_nat R) => /lt0r_neq0.
 rewrite (_ : _ / _ = rate r); last by rewrite -Hk card_ord.
 apply: (@lt_trans _ _ (2 `^ (- n%:R * epsilon0))).

--- a/information_theory/source_coding_fl_direct.v
+++ b/information_theory/source_coding_fl_direct.v
@@ -165,7 +165,9 @@ set F := f n S.
 set PHI := @phi _ n _ S def.
 exists (mkScode F PHI); split.
   rewrite /SrcRate /r /n /k.
-  by field; rewrite !nat1r/= !gt_eqF.
+  have dn0 : 1 + den%:R != 0 :> R by rewrite nat1r gt_eqF.
+  have k'n0 : 1 + k'%:R != 0 :> R by rewrite nat1r gt_eqF.
+  by field; do ?[apply/andP; split].  (* Remove "by " and "; do ?[apply/andP; split]" when requiring MathComp >= 2.6.0 *)
 set lhs := esrc(_, _).
 suff -> : lhs = 1 - Pr (P `^ k)%fdist (`TS P k (lambda / 2)).
   rewrite lerBlDr addrC -lerBlDr.

--- a/lib/realType_ext.v
+++ b/lib/realType_ext.v
@@ -668,7 +668,7 @@ Proof.
 move=> H.
 apply/val_inj; rewrite /= s_of_pqE p_of_rsE q_of_rsE p_of_rsE /=.
 rewrite /onem.
-field.
+suff ? : 1 - r%:num * s%:num != 0 by field.
 rewrite subr_eq0; apply: contra H => /eqP rs1.
 by apply/eqP/val_inj; rewrite /= p_of_rsE.
 Qed.
@@ -680,7 +680,7 @@ Proof.
 move=> H1 s0; apply/val_inj => /=.
 rewrite !(r_of_pqE,s_of_pqE,q_of_rsE,p_of_rsE) /onem.
 suff rs_neq1 : 1 - r%:num * s%:num != 0.
-  (field; do ?[apply/andP; split]) => //.
+  suff ? : 1 - (1 - r%:num * s%:num - (1 - r%:num) * s%:num) != 0 by field; do ?[apply/andP; split].  (* Remove "; do ?[apply/andP; split]" when requiring MathComp >= 2.6.0 *)
   by rewrite mulrBl mul1r !opprB -!addrA addrC !addrA !subrK ?subrr ?add0r.
 rewrite subr_eq0.
 apply: contra H1 => /eqP H1.
@@ -718,7 +718,8 @@ Lemma r_of_rpos_probA {R : realType} (p q r : {posnum R}) :
   divrposxxy p q.
 Proof.
 apply/val_inj; rewrite /= r_of_pqE s_of_pqE /onem /=.
-field; do ?[apply/andP; split]; do ?[by []].
+suff ? : (p%:num + (q%:num + r%:num)) * (q%:num + r%:num) -
+    (p%:num + (q%:num + r%:num) - p%:num) * (q%:num + r%:num - q%:num) != 0 by field; do ?[apply/andP; split].  (* Remove "; do ?[apply/andP; split]" when requiring MathComp >= 2.6.0 *)
 rewrite (addrC p%:num (q%:num + r%:num)%:pos%:num) addrK {4}[in q%:num + r%:num]addrC addrK.
 by rewrite mulrC -mulrBr (addrC _ p%:num) addrA addrK mulf_neq0//.
 Qed.

--- a/probability/convex_stone.v
+++ b/probability/convex_stone.v
@@ -542,10 +542,9 @@ congr (_ <| _ |> _).
   rewrite fdistI_permE permE /= p_of_rsE /= r_of_pqE /=.
   rewrite s_of_pqE /= /onem.
   rewrite (_ : Ordinal _ = lift ord0 ord0); last exact/val_inj.
-  set tmp1 := d _.
-  set tmp2 := d _.
-  field; rewrite ?oned0//=.
-  rewrite opprB opprB addrC addrA subrK.
+  set tmp1 := d _; set tmp2 := d _.
+  suff ? : 1 - (1 - tmp1 - tmp2) != 0 by field; do ?[apply/andP; split].  (* Remove "; do ?[apply/andP; split]" when requiring MathComp >= 2.6.0 *)
+  rewrite ?oned0//= opprB opprB addrC addrA subrK.
   by rewrite gt_eqF// addrC.
 - by rewrite /= /S3.p01 permE /=; congr g; exact/val_inj.
 - congr (_ <| _ |> _).
@@ -557,8 +556,8 @@ congr (_ <| _ |> _).
     set tmp2 := d _.
     have tmp12_neq0 : 1 - (1 - tmp1 - tmp2) != 0.
       by rewrite !opprB addrC addrA subrK gt_eqF// addrC.
-    field; do 1?[apply/andP; split]; rewrite ?oned0//.
-    rewrite subr_eq0 eq_sym.
+    suff ? : 1 - tmp2 != 0 by field; do ?[apply/andP; split].  (* Remove "; do ?[apply/andP; split]" when requiring MathComp >= 2.6.0 *)
+    rewrite ?oned0// subr_eq0 eq_sym.
     apply: contra ds01.
     rewrite /S3.p01 permE /= (_ : Ordinal _ = lift ord0 ord0) //.
     exact/val_inj.

--- a/probability/pinsker.v
+++ b/probability/pinsker.v
@@ -120,21 +120,23 @@ rewrite mulrBr; apply: is_deriveB=> /=; last first.
   rewrite expr1 -!mulr_regl.
   ring.
 rewrite (_ : q - p = p * (- (1 - q)) + (1 - p) * q ); last by ring.
+have l2n0 : ln 2 != 0 :> R by exact: ln2_neq0.
+have pn0 : p != 0 by rewrite gt_eqF.
+have qn0 : q != 0 by rewrite gt_eqF.
+have opn0 : 1 - p != 0 by rewrite subr_eq0 gt_eqF.
+have oqn0 : 1 - q != 0 by rewrite subr_eq0 gt_eqF.
 rewrite mulrDl; apply: is_deriveD=> /=.
   rewrite -!mulrA; apply: is_deriveZ=> /=.
   apply: is_derive1_LogfM_eq=> //.
   - by apply: is_deriveV; rewrite gt_eqF.
   - by rewrite invr_gt0.
-  - by rewrite mulr_algl -mulr_regl; field;
-      rewrite ?ln2_neq0 /= ?subr_eq0 ?gt_eqF//= !gt_eqF.
+  - by rewrite mulr_algl -mulr_regl; field; do ?[apply/andP; split].  (* Remove "by " and "; do ?[apply/andP; split]" when requiring MathComp >= 2.6.0 *)
 rewrite -!mulrA; apply: is_deriveZ=> /=.
 rewrite invfM mulrA mulfV ?gt_eqF//.
 apply: is_derive1_LogfM_eq=> //=.
-- by apply: is_deriveV; rewrite subr_eq0 gt_eqF.
 - by rewrite subr_gt0.
 - by rewrite invr_gt0 subr_gt0.
-  by rewrite -mulr_regl; field;
-    rewrite ?ln2_neq0 /= ?subr_eq0 ?gt_eqF.
+- by rewrite -mulr_regl; field; do ?[apply/andP; split].  (* Remove "by " and "; do ?[apply/andP; split]" when requiring MathComp >= 2.6.0 *)
 Qed.
 
 Lemma derive1_pinsker_fun (p : R) (Hp : 0 < p < 1) c q (Hq : 0 < q < 1) :
@@ -160,7 +162,9 @@ Proof.
 move: Hq=> /andP [q0 q1].
 apply: is_deriveB.
   apply: is_deriveN_eq; first by apply: is_derive1_Logf=> //; rewrite subr_gt0.
-  by simpl; field; rewrite ?ln2_neq0 ?subr_eq0 ?gt_eqF.
+  have l2n0 : ln 2 != 0 :> R by rewrite ln2_neq0.
+  have oqn0 : 1 - q != 0 by rewrite subr_eq0 gt_eqF.
+  by field; do ?[apply/andP; split].  (* Remove "by " and "; do ?[apply/andP; split]" when requiring MathComp >= 2.6.0 *)
 have->: 8 * c = 4 * c * 2 by ring.
 apply: is_deriveZ_eq.
 by rewrite -!mulr_regr; ring.

--- a/robust/robustmean.v
+++ b/robust/robustmean.v
@@ -725,7 +725,10 @@ apply: ler_pM.
 - rewrite ler_sqr ?nnegrE; lra.
 - rewrite -[leRHS]mulr1 ler_pdivlMl; last lra.
   rewrite [leLHS](_ : _ = 8 * eps * eps / (1 - 5 * eps)); last first.
-    rewrite /delta; field; do ?[apply/andP; split]; lra.
+    rewrite /delta.
+    have en0 : 1 - eps != 0 by lra.
+    have fen0 : 1 - 5 * eps != 0 by lra.
+    by field; do ?[apply/andP; split].  (* Remove "by " and "; do ?[apply/andP; split]" when requiring MathComp >= 2.6.0 *)
   rewrite ler_pdivrMr; last lra.
   rewrite mul1r (@le_trans _ _ eps) //; last lra.
   by rewrite ler_piMl //; lra.


### PR DESCRIPTION
Adapt to https://github.com/math-comp/math-comp/pull/1456/ (hopefully the last one)

For the context, it has been decided that `field` should be a terminating tactic. There is now `field?` with the old behavior, for development purposes.